### PR TITLE
refactor: reimplement vulpea-ui-widget using vui-collapsible

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 * Unreleased
 
+** Changed
+
+- Reimplement =vulpea-ui-widget= using =vui-collapsible= from vui-components internally. The public API remains unchanged.
+
 * v1.0.0 (2025-12-30)
 
 ** Added


### PR DESCRIPTION
## Summary

- Reimplement `vulpea-ui-widget` using `vui-collapsible` from vui-components internally
- Add `(require 'vui-components)` to imports
- Public API remains unchanged - downstream packages like vulpea-journal continue to work