### PR TITLE
feat: add error boundaries around widgets

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 * Unreleased
 
+** Added
+
+- Wrap widgets in =vui-error-boundary= for graceful error handling. A failing widget shows an error message instead of breaking the entire sidebar.
+
 ** Changed
 
 - Reimplement =vulpea-ui-widget= using =vui-collapsible= from vui-components internally. The public API remains unchanged.

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -1396,7 +1396,11 @@ Returns a list of plists with :note and :count, sorted by title."
           (vui-vstack
            :spacing 1
            (seq-map (lambda (widget-sym)
-                      (vui-component widget-sym :key widget-sym))
+                      (vui-error-boundary
+                        :id (intern (format "widget-%s" widget-sym))
+                        :fallback (lambda (_err)
+                                    (vui-muted (format "Error in %s" widget-sym)))
+                        (vui-component widget-sym :key widget-sym)))
                     widgets)))
       (vui-muted "No vulpea note selected"))))
 


### PR DESCRIPTION
## Summary

- Wrap each widget in `vui-error-boundary` in the sidebar content
- A failing widget now shows "Error in <widget-name>" instead of breaking the entire sidebar