### PR TITLE
docs: fix vui.el repository link

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -45,7 +45,7 @@ First release candidate.
 ** Features
 
 - Per-frame sidebar with configurable position and size
-- Widget system built on [[https://github.com/d12frosted/vui][vui]] components
+- Widget system built on [[https://github.com/d12frosted/vui.el][vui]] components
 - Widget registration system with predicates for context-aware display
 - Default widgets:
   - *Stats* - character count, word count, link count
@@ -65,4 +65,4 @@ First release candidate.
 
 - Emacs 29.1+
 - [[https://github.com/d12frosted/vulpea][vulpea]] (v2)
-- [[https://github.com/d12frosted/vui][vui]]
+- [[https://github.com/d12frosted/vui.el][vui]]

--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@ Sidebar infrastructure and widget framework for [[https://github.com/d12frosted/
 * Features
 
 - Per-frame sidebar with configurable position and size
-- Widget system built on [[https://github.com/d12frosted/vui][vui]] components
+- Widget system built on [[https://github.com/d12frosted/vui.el][vui]] components
 - Default widgets: outline, backlinks, forward links, stats
 - Easy API for creating custom widgets
 - Auto-hide when switching to non-vulpea buffers
@@ -28,7 +28,7 @@ Sidebar infrastructure and widget framework for [[https://github.com/d12frosted/
 
 - Emacs 29.1+
 - [[https://github.com/d12frosted/vulpea][vulpea]] (v2)
-- [[https://github.com/d12frosted/vui][vui]]
+- [[https://github.com/d12frosted/vui.el][vui]]
 
 ** Using package.el (MELPA)
 


### PR DESCRIPTION
## Summary

Fix broken link to vui.el repository in README and CHANGELOG.

Closes #1