### PR TITLE
fix[buffer-name] recover sidebar-buf when frame-title is dynamic

### DIFF
--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -335,7 +335,7 @@ Used to prevent re-entry during render.")
   "Return the sidebar buffer name for FRAME.
 If FRAME is nil, use the selected frame."
   (let ((frame (or frame (selected-frame))))
-    (format "*vulpea-ui-sidebar:%s*" (frame-parameter frame 'window-id))))
+    (format "*vulpea-ui-sidebar:%s*" (or (frame-parameter frame 'window-id) ""))))
 
 (defun vulpea-ui--get-sidebar-buffer (&optional frame)
   "Get the sidebar buffer for FRAME, or nil if it doesn't exist."


### PR DESCRIPTION
This is a quick fix for issue #6
https://github.com/d12frosted/vulpea-ui/issues/6

- This has not been tested thoroughly as I am only starting to use vulpea and don't know the featureset yet.
- This results in relatively uninformative buffer name (like: "*vulpea-ui-sidebar:1*"). Possibly other information should be included.
- Alternatively a custom frame parameter could be attached for each frame that is guaranteed to be stable and could include    more information