### PR TITLE
feat: enable mode-line-invisible-mode in sidebar by default

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Reimplement =vulpea-ui-widget= using =vui-collapsible= from vui-components internally. The public API remains unchanged.
 - Use =vui-muted= semantic component for de-emphasized text.
+- Enable =mode-line-invisible-mode= in sidebar by default for a cleaner UI. Can be toggled off if needed.
 
 * v1.0.0 (2025-12-30)
 

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -313,7 +313,8 @@ Widgets are filtered by predicate and sorted by order."
   "Major mode for the vulpea-ui sidebar buffer.
 \\{vulpea-ui-sidebar-mode-map}"
   :group 'vulpea-ui
-  (setq-local truncate-lines t))
+  (setq-local truncate-lines t)
+  (mode-line-invisible-mode 1))
 
 
 ;;; Sidebar state (frame-local)


### PR DESCRIPTION
## Summary

- Enable `mode-line-invisible-mode` in sidebar by default for a cleaner UI
- Users can toggle it off with `M-x mode-line-invisible-mode` if needed

Closes #8