### PR TITLE
fix: preserve collapsible section state during refresh

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 * Unreleased
 
+** Fixed
+
+- Preserve collapsible section state during automatic refresh. Previously, collapsed widgets would reset to default state on idle/save refresh.
+
 ** Changed
 
 - Reimplement =vulpea-ui-widget= using =vui-collapsible= from vui-components internally. The public API remains unchanged.


### PR DESCRIPTION
## Summary

- Preserve collapsed/expanded state of widget sections during automatic refresh

## Problem

When automatic refresh occurs (idle timer, save), collapsible widget sections would reset to their default state. This was frustrating when you had collapsed a section to focus on others.

## Solution

Use `vui-update` instead of `vui-mount` when refreshing an existing sidebar. This leverages vui's reconciliation to preserve UI state while invalidating memos to refresh computed data.

```elisp
;; Before: always mount fresh (loses state)
(vui-mount ...)

;; After: update existing instance (preserves state)
(vui-update existing-instance (list :note note))
```

Requires vui.el with `vui-update` (merged in d12frosted/vui.el#37).