### PR TITLE
fix: eliminate sidebar flicker during idle refresh

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ** Fixed
 
 - Preserve collapsible section state during automatic refresh. Previously, collapsed widgets would reset to default state on idle/save refresh.
+- Eliminate sidebar flicker during idle refresh. Idle timer now uses soft update (=vui-update-props=) preserving memo caches — only widgets whose deps changed (stats/outline via =buffer-modified-tick=) recompute. Save and manual refresh still invalidate all caches.
+- Outline widget now reads from buffer when available (like stats), enabling live heading updates while editing.
 
 ** Changed
 


### PR DESCRIPTION
## Summary

- Idle timer uses `vui-update-props` (soft update) instead of `vulpea-ui-sidebar-refresh`, preserving memo caches so only widgets with changed deps recompute
- Stats and outline widgets add `buffer-modified-tick` to memo deps, detecting actual buffer edits without global memo invalidation
- Outline parser reads from buffer when available (like stats already does), enabling live heading updates while editing
- `render-sidebar` uses soft update — memos recompute naturally when the note dep changes
- `sidebar-refresh` (save hook / manual) keeps using `vui-update` (hard) to invalidate all caches

Depends on d12frosted/vui.el#38 (`vui-update-props`).