### PR TITLE
fix: guard mode-line-invisible-mode call with fboundp

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 * Unreleased
 
+** Fixed
+
+- Guard =mode-line-invisible-mode= call with =fboundp= since it is only available starting from Emacs 31.
+
 * v1.1.0 (2026-01-31)
 
 ** Fixed

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -309,7 +309,8 @@ Widgets are filtered by predicate and sorted by order."
 \\{vulpea-ui-sidebar-mode-map}"
   :group 'vulpea-ui
   (setq-local truncate-lines t)
-  (mode-line-invisible-mode 1))
+  (when (fboundp 'mode-line-invisible-mode)
+    (mode-line-invisible-mode 1)))
 
 
 ;;; Sidebar state (frame-local)


### PR DESCRIPTION
## Summary

- Guard `mode-line-invisible-mode` call with `fboundp` since it is only available starting from Emacs 31
- Update CHANGELOG

Closes #17