### PR TITLE
fix: suppress inline previews in parsing temp buffers

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ** Fixed
 
 - Guard =mode-line-invisible-mode= call with =fboundp= since it is only available starting from Emacs 31.
+- Suppress inline image and LaTeX previews in parsing temp buffers, fixing crash when sidebar encounters notes with =attachment:= links and =#+startup: inlineimages= ([[https://github.com/d12frosted/vulpea-ui/issues/21][#21]]).
 
 * v1.1.0 (2026-01-31)
 

--- a/test/vulpea-ui-test.el
+++ b/test/vulpea-ui-test.el
@@ -411,5 +411,40 @@ In batch mode, execute BODY in the current frame instead."
   (should-not vulpea-ui-fast-parse))
 
 
+;;; Parse headings tests
+
+(ert-deftest vulpea-ui-test-parse-headings-with-attachment-link ()
+  "Test that parsing headings works with attachment links.
+Regression test for issue #21: inline image previews in temp
+buffers crash because `org-attach-id-dir' is relative and the
+buffer has no filename."
+  (let* ((temp-file (make-temp-file "vulpea-ui-test" nil ".org"))
+         (note (make-vulpea-note
+                :id "test-attach"
+                :path temp-file
+                :level 0
+                :pos 1
+                :title "Test with attachment"
+                :primary-title "Test with attachment"
+                :aliases nil
+                :tags nil
+                :links nil
+                :properties nil
+                :meta nil)))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert "#+startup: inlineimages\n"
+                    "* Heading One\n"
+                    "Some text with [[attachment:image.png]]\n"
+                    "* Heading Two\n"
+                    "More content\n"))
+          (let ((headings (vulpea-ui--parse-headings note)))
+            (should (= (length headings) 2))
+            (should (equal (plist-get (nth 0 headings) :title) "Heading One"))
+            (should (equal (plist-get (nth 1 headings) :title) "Heading Two"))))
+      (delete-file temp-file))))
+
+
 (provide 'vulpea-ui-test)
 ;;; vulpea-ui-test.el ends here

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -517,10 +517,14 @@ stats and outline) will recompute."
 
 (defun vulpea-ui--setup-org-mode ()
   "Set up `org-mode' for parsing, respecting `vulpea-ui-fast-parse'.
-When fast parsing is enabled, skip mode hooks for better performance."
-  (if vulpea-ui-fast-parse
-      (delay-mode-hooks (org-mode))
-    (org-mode)))
+When fast parsing is enabled, skip mode hooks for better performance.
+Inline images and LaTeX previews are always suppressed since
+these buffers are used only for parsing."
+  (let ((org-startup-with-inline-images nil)
+        (org-startup-with-latex-preview nil))
+    (if vulpea-ui-fast-parse
+        (delay-mode-hooks (org-mode))
+      (org-mode))))
 
 (defun vulpea-ui-clean-org-markup (text)
   "Clean `org-mode' markup from TEXT for display purposes.


### PR DESCRIPTION
## Summary

- Suppress `org-startup-with-inline-images` and `org-startup-with-latex-preview` in `vulpea-ui--setup-org-mode` to prevent org-mode from attempting to render previews in temp buffers used only for parsing.
- The root cause: temp buffers have no `buffer-file-name`, so `org-attach-dir` cannot resolve a relative `org-attach-id-dir` (default `data/`), causing `org-attach-check-absolute-path` to error.
- Affects both `vulpea-ui--parse-headings` and `vulpea-ui--enrich-backlink-mentions`.

Fixes #21