### PR TITLE
fix: use org-inhibit-startup in parsing temp buffers

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Guard =mode-line-invisible-mode= call with =fboundp= since it is only available starting from Emacs 31.
 - Suppress inline image and LaTeX previews in parsing temp buffers, fixing crash when sidebar encounters notes with =attachment:= links and =#+startup: inlineimages= ([[https://github.com/d12frosted/vulpea-ui/issues/21][#21]]).
+- Use =org-inhibit-startup= instead of individual variable suppression in parsing buffers, fixing crash when buffer-level =#+startup: inlineimages= keyword overrides let-bound variables in newer Emacs/Org versions ([[https://github.com/d12frosted/vulpea-ui/issues/23][#23]]).
 
 * v1.1.0 (2026-01-31)
 

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -520,7 +520,7 @@ stats and outline) will recompute."
 When fast parsing is enabled, skip mode hooks for better performance.
 All startup actions (inline images, LaTeX previews, visibility
 cycling) are inhibited since these buffers are used only for
-parsing.  Using `org-inhibit-startup' prevents org-mode from
+parsing.  Using `org-inhibit-startup' prevents `org-mode' from
 processing buffer-level #+STARTUP keywords (e.g. inlineimages)
 which would otherwise override let-bound variable suppression."
   (let ((org-inhibit-startup t))

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -518,10 +518,12 @@ stats and outline) will recompute."
 (defun vulpea-ui--setup-org-mode ()
   "Set up `org-mode' for parsing, respecting `vulpea-ui-fast-parse'.
 When fast parsing is enabled, skip mode hooks for better performance.
-Inline images and LaTeX previews are always suppressed since
-these buffers are used only for parsing."
-  (let ((org-startup-with-inline-images nil)
-        (org-startup-with-latex-preview nil))
+All startup actions (inline images, LaTeX previews, visibility
+cycling) are inhibited since these buffers are used only for
+parsing.  Using `org-inhibit-startup' prevents org-mode from
+processing buffer-level #+STARTUP keywords (e.g. inlineimages)
+which would otherwise override let-bound variable suppression."
+  (let ((org-inhibit-startup t))
     (if vulpea-ui-fast-parse
         (delay-mode-hooks (org-mode))
       (org-mode))))


### PR DESCRIPTION
## Summary

- Replace individual `org-startup-with-inline-images` / `org-startup-with-latex-preview` let-bindings with `org-inhibit-startup` in `vulpea-ui--setup-org-mode`
- `org-inhibit-startup` is a top-level guard that prevents org-mode from processing any `#+STARTUP` keywords and running any startup actions — the correct approach for parsing-only temp buffers

The previous fix (#22) let-bound individual startup variables, but when the buffer contains `#+startup: inlineimages`, org-mode processes that keyword during initialization and sets `org-startup-with-link-previews` (a newer variable in recent Emacs/Org) buffer-locally, overriding the let-bound suppression. This still triggers `org-link-preview`, which crashes on `attachment:` links in the filename-less temp buffer.

Fixes #23