### PR TITLE
fix: strip org markup from outline heading titles

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Guard =mode-line-invisible-mode= call with =fboundp= since it is only available starting from Emacs 31.
 - Suppress inline image and LaTeX previews in parsing temp buffers, fixing crash when sidebar encounters notes with =attachment:= links and =#+startup: inlineimages= ([[https://github.com/d12frosted/vulpea-ui/issues/21][#21]]).
 - Use =org-inhibit-startup= instead of individual variable suppression in parsing buffers, fixing crash when buffer-level =#+startup: inlineimages= keyword overrides let-bound variables in newer Emacs/Org versions ([[https://github.com/d12frosted/vulpea-ui/issues/23][#23]]).
+- Strip org markup from outline heading titles so links and similar constructs no longer show as raw markup in the outline ([[https://github.com/d12frosted/vulpea-ui/issues/20][#20]]).
 
 * v1.1.0 (2026-01-31)
 

--- a/test/vulpea-ui-test.el
+++ b/test/vulpea-ui-test.el
@@ -445,6 +445,36 @@ buffer has no filename."
             (should (equal (plist-get (nth 1 headings) :title) "Heading Two"))))
       (delete-file temp-file))))
 
+(ert-deftest vulpea-ui-test-parse-headings-cleans-org-markup ()
+  "Test that heading titles are stripped of org markup.
+Regression test for issue #20: outline headings were shown with
+raw org markup such as links and emphasis."
+  (let* ((temp-file (make-temp-file "vulpea-ui-test" nil ".org"))
+         (note (make-vulpea-note
+                :id "test-markup"
+                :path temp-file
+                :level 0
+                :pos 1
+                :title "Test with markup"
+                :primary-title "Test with markup"
+                :aliases nil
+                :tags nil
+                :links nil
+                :properties nil
+                :meta nil)))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert "* See [[id:abc123][Other Note]]\n"
+                    "Some content\n"
+                    "* Visit [[https://example.com][Example]] now\n"
+                    "More content\n"))
+          (let ((headings (vulpea-ui--parse-headings note)))
+            (should (= (length headings) 2))
+            (should (equal (plist-get (nth 0 headings) :title) "See Other Note"))
+            (should (equal (plist-get (nth 1 headings) :title) "Visit Example now"))))
+      (delete-file temp-file))))
+
 
 (provide 'vulpea-ui-test)
 ;;; vulpea-ui-test.el ends here

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -797,7 +797,8 @@ Returns a list of plists with :title, :level, and :pos."
           (org-element-map (org-element-parse-buffer 'headline) 'headline
             (lambda (hl)
               (let ((level (org-element-property :level hl))
-                    (title (org-element-property :raw-value hl))
+                    (title (vulpea-ui--clean-org-links
+                            (org-element-property :raw-value hl)))
                     (pos (org-element-property :begin hl)))
                 (when (and (not (vulpea-ui--heading-archived-p hl archive-tag))
                            (or (null max-depth) (<= level max-depth)))


### PR DESCRIPTION
Outline headings were rendered from the headline's raw value, so any org markup (links, etc.) appeared as raw text in the sidebar outline. The `vulpea-ui-clean-org-markup` utility and the equivalent fix for backlink heading paths (fddd712) already existed, but the outline widget was never wired up to use them.

This cleans heading titles via `vulpea-ui--clean-org-links` at parse time in `vulpea-ui--parse-headings`, so the stored title is display-ready and matches how backlink heading paths are handled. Reporters no longer need the `:filter-return` advice workaround.

Closes #20