### PR TITLE
feat: add unlinked mentions sidebar widget

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 * Unreleased
 
+** Added
+
+- Unlinked mentions widget showing notes that mention the current note's title or aliases as plain text without an =id:= link back. It is the sidebar's first asynchronous widget: the search is delegated to =vulpea-note-unlinked-mentions-async= (ripgrep) and rendered via =vui-use-async=, so it shows a loading state, fills in when results arrive, and caches them until the note changes or the sidebar is refreshed. Requires [[https://github.com/BurntSushi/ripgrep][ripgrep]] and vulpea 2.4.0+ ([[https://github.com/d12frosted/vulpea-ui/issues/13][#13]]).
+
 ** Documentation
 
 - Document =vulpea-ui-widget-set= as the public way to attach a predicate to an already-registered widget, with a worked example showing how to toggle a built-in widget per note via a defvar + an org property ([[https://github.com/d12frosted/vulpea-ui/issues/25][#25]]).

--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@ Sidebar infrastructure and widget framework for [[https://github.com/d12frosted/
 
 - Per-frame sidebar with configurable position and size
 - Widget system built on [[https://github.com/d12frosted/vui.el][vui]] components
-- Default widgets: outline, backlinks, forward links, stats
+- Default widgets: outline, backlinks, unlinked mentions, forward links, stats
 - Easy API for creating custom widgets
 - Auto-hide when switching to non-vulpea buffers
 
@@ -29,8 +29,9 @@ Sidebar infrastructure and widget framework for [[https://github.com/d12frosted/
 ** Dependencies
 
 - Emacs 29.1+
-- [[https://github.com/d12frosted/vulpea][vulpea]] (v2)
-- [[https://github.com/d12frosted/vui.el][vui]]
+- [[https://github.com/d12frosted/vulpea][vulpea]] 2.4.0+
+- [[https://github.com/d12frosted/vui.el][vui]] 1.0+
+- [[https://github.com/BurntSushi/ripgrep][ripgrep]] - optional, used by the [[*Unlinked mentions widget][unlinked mentions widget]]
 
 ** Using package.el (MELPA)
 
@@ -205,6 +206,27 @@ Shows notes that link to the current note, grouped by file with:
   - =†= footnote
   - (no indicator) prose
 
+** Unlinked mentions widget
+
+Shows notes that mention the current note's title or one of its aliases
+as plain text, *without* an =id:= link pointing back - the notes you may
+want to link. Mentions are grouped by the mentioning note; click a
+context line to jump to it.
+
+Unlike the other widgets, this one loads *asynchronously*: scanning the
+whole collection for a note's title is expensive, so the search is
+delegated to [[https://github.com/BurntSushi/ripgrep][ripgrep]] via =vulpea-note-unlinked-mentions-async= and the
+widget shows a =Searching…= state until results arrive. Results are
+cached until you switch notes or refresh the sidebar (=g= /
+=vulpea-ui-sidebar-refresh=); an idle soft-refresh reuses the cache.
+
+If ripgrep is not on =exec-path= the widget reports it instead of
+failing. To disable the widget entirely:
+
+#+begin_src emacs-lisp
+(vulpea-ui-unregister-widget 'unlinked-mentions)
+#+end_src
+
 ** Links widget
 
 #+begin_html
@@ -223,12 +245,13 @@ Widgets are registered with =vulpea-ui-register-widget=, which allows filtering 
 
 vulpea-ui registers these widgets by default:
 
-| Widget      | Order | Component                   |
-|-------------+-------+-----------------------------|
-| =stats=     |   100 | =vulpea-ui-widget-stats=    |
-| =outline=   |   200 | =vulpea-ui-widget-outline=  |
-| =backlinks= |   300 | =vulpea-ui-widget-backlinks= |
-| =links=     |   400 | =vulpea-ui-widget-links=    |
+| Widget              | Order | Component                            |
+|---------------------+-------+--------------------------------------|
+| =stats=             |   100 | =vulpea-ui-widget-stats=             |
+| =outline=           |   200 | =vulpea-ui-widget-outline=           |
+| =backlinks=         |   300 | =vulpea-ui-widget-backlinks=         |
+| =unlinked-mentions= |   350 | =vulpea-ui-widget-unlinked-mentions= |
+| =links=             |   400 | =vulpea-ui-widget-links=             |
 
 ** Registering widgets
 

--- a/test/vulpea-ui-test.el
+++ b/test/vulpea-ui-test.el
@@ -12,6 +12,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-lib)
 (require 'vulpea-ui)
 
 ;;; Test helpers
@@ -602,6 +603,109 @@ Mirrors the example from the README."
                     (vulpea-ui--get-widgets-for-note
                      (vulpea-ui-test--make-mock-note
                       nil nil '(("SHOW_W" . "t")))))))))
+
+
+;;; Unlinked mentions grouping tests
+
+(ert-deftest vulpea-ui-test-group-mentions-empty ()
+  "Grouping an empty mention list yields nil."
+  (should (null (vulpea-ui--group-mentions nil))))
+
+(ert-deftest vulpea-ui-test-group-mentions-by-note ()
+  "Mentions are grouped by mentioning note, preserving order.
+Groups appear in first-encounter order; mentions keep their order
+within a group and carry :line and :context."
+  (let* ((a (vulpea-ui-test--make-mock-note "id-a" "Note A"))
+         (b (vulpea-ui-test--make-mock-note "id-b" "Note B"))
+         (mentions (list
+                    (list :note a :path "/a.org" :line 3 :context "first a")
+                    (list :note b :path "/b.org" :line 7 :context "only b")
+                    (list :note a :path "/a.org" :line 9 :context "second a")))
+         (groups (vulpea-ui--group-mentions mentions)))
+    ;; Two groups, in first-seen order: A then B
+    (should (= (length groups) 2))
+    (should (equal (vulpea-note-id (plist-get (nth 0 groups) :note)) "id-a"))
+    (should (equal (plist-get (nth 0 groups) :path) "/a.org"))
+    (should (equal (vulpea-note-id (plist-get (nth 1 groups) :note)) "id-b"))
+    ;; A keeps both mentions in original order
+    (let ((a-mentions (plist-get (nth 0 groups) :mentions)))
+      (should (= (length a-mentions) 2))
+      (should (= (plist-get (nth 0 a-mentions) :line) 3))
+      (should (equal (plist-get (nth 0 a-mentions) :context) "first a"))
+      (should (= (plist-get (nth 1 a-mentions) :line) 9))
+      (should (equal (plist-get (nth 1 a-mentions) :context) "second a")))
+    ;; B has its single mention
+    (let ((b-mentions (plist-get (nth 1 groups) :mentions)))
+      (should (= (length b-mentions) 1))
+      (should (= (plist-get (nth 0 b-mentions) :line) 7))
+      (should (equal (plist-get (nth 0 b-mentions) :context) "only b")))))
+
+(ert-deftest vulpea-ui-test-group-mentions-single-group ()
+  "Multiple mentions from one note collapse into a single group."
+  (let* ((a (vulpea-ui-test--make-mock-note "id-a" "Note A"))
+         (mentions (list
+                    (list :note a :path "/a.org" :line 1 :context "one")
+                    (list :note a :path "/a.org" :line 2 :context "two")))
+         (groups (vulpea-ui--group-mentions mentions)))
+    (should (= (length groups) 1))
+    (should (= (length (plist-get (nth 0 groups) :mentions)) 2))))
+
+
+;;; Unlinked mentions widget render tests
+
+(defmacro vulpea-ui-test--render-mentions (mentions-form &rest body)
+  "Render the unlinked-mentions widget and run BODY with OUTPUT bound.
+
+`vulpea-note-unlinked-mentions-async' is stubbed to resolve
+synchronously with MENTIONS-FORM, so the whole async pipeline runs
+deterministically with no ripgrep and no event loop.  OUTPUT is the
+rendered sidebar buffer text.  The widget registry is isolated to the
+unlinked-mentions widget for the duration of the render."
+  (declare (indent 1))
+  `(vulpea-ui-test--with-clean-registry
+     (vulpea-ui-register-widget 'unlinked-mentions
+                                :component 'vulpea-ui-widget-unlinked-mentions
+                                :order 350)
+     (let ((note (vulpea-ui-test--make-mock-note "tgt" "Target"))
+           (buf-name "*vulpea-ui-mentions-test*"))
+       (with-current-buffer (get-buffer-create buf-name)
+         (vulpea-ui-sidebar-mode))
+       (cl-letf (((symbol-function 'vulpea-note-unlinked-mentions-async)
+                  (lambda (_note resolve _reject)
+                    (funcall resolve ,mentions-form)
+                    nil)))
+         (unwind-protect
+             (progn
+               (vui-mount (vui-component 'vulpea-ui-sidebar-root :note note)
+                          buf-name)
+               (let ((output (with-current-buffer buf-name
+                               (buffer-substring-no-properties
+                                (point-min) (point-max)))))
+                 ,@body))
+           (when (get-buffer buf-name)
+             (kill-buffer buf-name)))))))
+
+(ert-deftest vulpea-ui-test-mentions-widget-ready ()
+  "Resolved mentions render grouped under each mentioning note with a count."
+  (let ((a (vulpea-ui-test--make-mock-note "id-a" "Note A"))
+        (b (vulpea-ui-test--make-mock-note "id-b" "Note B")))
+    (vulpea-ui-test--render-mentions
+        (list (list :note a :path "/a.org" :line 3 :context "mentions Target here")
+              (list :note a :path "/a.org" :line 9 :context "Target again")
+              (list :note b :path "/b.org" :line 5 :context "a Target reference"))
+      ;; Header shows the total number of mentions (not groups)
+      (should (string-match-p "Unlinked Mentions (3)" output))
+      ;; Both mentioning notes appear, with their context lines
+      (should (string-match-p "Note A" output))
+      (should (string-match-p "Note B" output))
+      (should (string-match-p "mentions Target here" output))
+      (should (string-match-p "Target again" output))
+      (should (string-match-p "a Target reference" output)))))
+
+(ert-deftest vulpea-ui-test-mentions-widget-empty ()
+  "No mentions renders the empty-state message."
+  (vulpea-ui-test--render-mentions nil
+    (should (string-match-p "No unlinked mentions" output))))
 
 
 (provide 'vulpea-ui-test)

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
 ;; URL: https://github.com/d12frosted/vulpea-ui
 ;; Version: 1.1.0
-;; Package-Requires: ((emacs "29.1") (vulpea "2.0.0") (vui "0.1"))
+;; Package-Requires: ((emacs "29.1") (vulpea "2.4.0") (vui "1.0"))
 ;; Keywords: outlines hypermedia
 
 ;; This file is NOT part of GNU Emacs.
@@ -34,7 +34,8 @@
 ;; Features:
 ;; - Per-frame sidebar with configurable position and size
 ;; - Widget system built on vui components
-;; - Default widgets: outline, backlinks, forward links, stats
+;; - Default widgets: outline, backlinks, unlinked mentions, forward
+;;   links, stats
 ;; - Easy API for creating custom widgets
 ;;
 ;; Usage:
@@ -294,6 +295,11 @@ Widgets are filtered by predicate and sorted by order."
   "Face for context type indicators (§, •, >, etc.) in backlink previews."
   :group 'vulpea-ui)
 
+(defface vulpea-ui-mention-context-face
+  '((t :inherit shadow))
+  "Face for the context line of an unlinked mention."
+  :group 'vulpea-ui)
+
 
 ;;; Major mode
 
@@ -327,6 +333,13 @@ Used to prevent re-entry during render.")
 
 (defvar vulpea-ui--idle-timer nil
   "Timer for auto-refreshing sidebar on idle.")
+
+(defvar-local vulpea-ui--refresh-generation 0
+  "Counter bumped on each explicit sidebar refresh.
+Async widgets fold this into their `vui-use-async' cache key so that a
+manual or save-triggered refresh (`vulpea-ui-sidebar-refresh', which
+invalidates memos) re-runs them, while an idle soft-refresh
+\(`vui-update-props', which does not bump it) reuses the cached result.")
 
 (defun vulpea-ui--sidebar-buffer-name (&optional frame)
   "Return the sidebar buffer name for FRAME.
@@ -1380,6 +1393,118 @@ Returns a list of plists with :note and :count, sorted by title."
                   result)))))
 
 
+;;; Unlinked mentions widget
+
+(vui-defcomponent vulpea-ui-widget-unlinked-mentions ()
+  "Widget displaying notes that mention the current note without linking.
+
+An unlinked mention is a place where another note writes this note's
+title or one of its aliases as plain text, with no `id:' link pointing
+back.  The search is delegated to `vulpea-note-unlinked-mentions-async'
+\(ripgrep-backed) and runs asynchronously, so the widget shows a loading
+state and fills in when the results arrive.  Results are cached until the
+note changes or the sidebar is refreshed via `vulpea-ui-sidebar-refresh'.
+
+This is the sidebar's first asynchronous widget; it relies on ripgrep
+being available on `exec-path' and reports gracefully when it is not."
+  :render
+  (let ((note (use-vulpea-ui-note)))
+    (when note
+      (let* ((result (vui-use-async
+                         (list (vulpea-note-id note)
+                               vulpea-ui--refresh-generation)
+                       (apply-partially
+                        #'vulpea-note-unlinked-mentions-async note)))
+             (status (plist-get result :status)))
+        (vui-component 'vulpea-ui-widget
+          :title "Unlinked Mentions"
+          :count (when (eq status 'ready)
+                   (length (plist-get result :data)))
+          :children
+          (lambda ()
+            (pcase status
+              ('ready
+               (let ((groups (vulpea-ui--group-mentions
+                              (plist-get result :data))))
+                 (if groups
+                     (vui-vstack
+                      :spacing 1
+                      (seq-map #'vulpea-ui--render-mention-group groups))
+                   (vui-muted "No unlinked mentions"))))
+              ('error
+               (vui-muted (format "Unavailable: %s"
+                                  (plist-get result :error))))
+              (_ (vui-muted "Searching…")))))))))
+
+(defun vulpea-ui--group-mentions (mentions)
+  "Group MENTIONS by their mentioning note.
+
+MENTIONS is the list resolved by `vulpea-note-unlinked-mentions-async':
+each is a plist with :note (the mentioning `vulpea-note'), :path, :line,
+and :context.
+
+Returns a list of group plists, one per mentioning note in
+first-encounter order, each with :note, :path, and :mentions - a list of
+\(:line :context) plists kept in their original order."
+  (let ((meta (make-hash-table :test 'equal))
+        (lists (make-hash-table :test 'equal))
+        (order nil))
+    (dolist (m mentions)
+      (let* ((note (plist-get m :note))
+             (id (and note (vulpea-note-id note))))
+        (when id
+          (unless (gethash id meta)
+            (push id order)
+            (puthash id (list :note note :path (plist-get m :path)) meta))
+          (push (list :line (plist-get m :line)
+                      :context (plist-get m :context))
+                (gethash id lists)))))
+    (mapcar (lambda (id)
+              (let ((info (gethash id meta)))
+                (list :note (plist-get info :note)
+                      :path (plist-get info :path)
+                      :mentions (nreverse (gethash id lists)))))
+            (nreverse order))))
+
+(defun vulpea-ui--render-mention-group (group)
+  "Render a mention GROUP: the mentioning note link and its context lines."
+  (let ((note (plist-get group :note))
+        (path (plist-get group :path))
+        (mentions (plist-get group :mentions)))
+    (vui-vstack
+     :spacing 0
+     (if note
+         (vui-component 'vulpea-ui-note-link :note note)
+       (vui-muted (file-name-nondirectory path)))
+     (vui-vstack
+      :spacing 0
+      :indent 2
+      (seq-map (lambda (m) (vulpea-ui--render-mention m path)) mentions)))))
+
+(defun vulpea-ui--render-mention (mention path)
+  "Render a single MENTION from PATH as a clickable context line.
+Clicking jumps to the mention's line in the main window."
+  (let ((line (plist-get mention :line))
+        (context (plist-get mention :context)))
+    (vui-button context
+      :face 'vulpea-ui-mention-context-face
+      :no-decoration t
+      :on-click (lambda () (vulpea-ui--jump-to-file-line path line))
+      :help-echo nil)))
+
+(defun vulpea-ui--jump-to-file-line (path line)
+  "Jump to LINE in the file at PATH in the main window."
+  (when (and path line)
+    (let ((main-win (vulpea-ui--get-main-window)))
+      (when main-win
+        (select-window main-win)
+        (find-file path)
+        (goto-char (point-min))
+        (forward-line (1- line))
+        (org-fold-show-entry)
+        (recenter)))))
+
+
 ;;; Root component
 
 (vui-defcomponent vulpea-ui-sidebar-content ()
@@ -1499,7 +1624,8 @@ Returns a list of plists with :note and :count, sorted by title."
                (vui-instance-buffer instance)
                (buffer-live-p (vui-instance-buffer instance)))
       (with-current-buffer (vui-instance-buffer instance)
-        (setq vulpea-ui--current-note note))
+        (setq vulpea-ui--current-note note)
+        (cl-incf vulpea-ui--refresh-generation))
       (vui-update instance (list :note note)))))
 
 
@@ -1516,6 +1642,10 @@ Returns a list of plists with :note and :count, sorted by title."
 (vulpea-ui-register-widget 'backlinks
                            :component 'vulpea-ui-widget-backlinks
                            :order 300)
+
+(vulpea-ui-register-widget 'unlinked-mentions
+                           :component 'vulpea-ui-widget-unlinked-mentions
+                           :order 350)
 
 (vulpea-ui-register-widget 'links
                            :component 'vulpea-ui-widget-links


### PR DESCRIPTION
Implements the unlinked mentions sidebar widget from #13: a section showing notes that mention the current note's title or aliases as plain text without an `id:` link back — the notes you may want to link.

## What

- New `vulpea-ui-widget-unlinked-mentions` (registered at order 350, between backlinks and links), the sidebar's first **asynchronous** widget. It wraps vulpea's `vulpea-note-unlinked-mentions-async` (ripgrep-backed) in `vui-use-async`: a loading state, results grouped by mentioning note with each context line clickable to jump there, and graceful reporting when ripgrep is unavailable.
- Results are cached until the note changes or the sidebar is refreshed. A buffer-local refresh generation, bumped by `vulpea-ui-sidebar-refresh`, is folded into the async cache key, so manual (`g`) and save-triggered refresh re-run the search while idle soft-refresh reuses the cache.
- Bumps `Package-Requires` to `vulpea 2.4.0` (the released async query) and `vui 1.0` (where `vui-use-async` was introduced; previously understated as `0.1`).

## Why

The contextual "unlinked references" view, dual to the backlinks widget: it surfaces implicit references so they can be turned into real links. It also establishes the `vui-use-async` pattern for future IO-bound widgets.

## Notes

- On by default; disable with `(vulpea-ui-unregister-widget 'unlinked-mentions)`.
- Scope is the listing + visit half of #13; the "convert mention → link" action and the outgoing direction (what the current buffer could link) are planned follow-ups.

Depends on vulpea#210 (shipped in vulpea 2.4.0). Part of #13.
