### PR TITLE
fix: create sidebar window regardless of window-sides-slots

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ** Fixed
 
+- Display the sidebar even when the user disabled side windows on its configured side via =window-sides-slots= (e.g. ='(1 0 0 1)= to forbid right-side windows). Previously =display-buffer-in-side-window= returned nil, the sidebar buffer silently took over the selected window, and a follow-up auto-hide attempt errored with "Attempt to delete ... sole ordinary window". A local copy of =window-sides-slots= now guarantees the sidebar's side at least one slot ([[https://github.com/d12frosted/vulpea-journal/issues/21][vulpea-journal#21]]).
 - Guard =mode-line-invisible-mode= call with =fboundp= since it is only available starting from Emacs 31.
 - Suppress inline image and LaTeX previews in parsing temp buffers, fixing crash when sidebar encounters notes with =attachment:= links and =#+startup: inlineimages= ([[https://github.com/d12frosted/vulpea-ui/issues/21][#21]]).
 - Use =org-inhibit-startup= instead of individual variable suppression in parsing buffers, fixing crash when buffer-level =#+startup: inlineimages= keyword overrides let-bound variables in newer Emacs/Org versions ([[https://github.com/d12frosted/vulpea-ui/issues/23][#23]]).

--- a/test/vulpea-ui-test.el
+++ b/test/vulpea-ui-test.el
@@ -128,6 +128,51 @@ leak into the saved snapshot."
       (should (null (alist-get 'window-width params))))))
 
 
+;;; Side slot guarantee tests
+
+(ert-deftest vulpea-ui-test-ensure-side-slot-raises-disabled ()
+  "A disabled side (zero slots) is raised to a single slot."
+  (should (equal (vulpea-ui--ensure-side-slot '(1 0 0 1) 'right)
+                 '(1 0 1 1)))
+  (should (equal (vulpea-ui--ensure-side-slot '(0 0 0 0) 'left)
+                 '(1 0 0 0)))
+  (should (equal (vulpea-ui--ensure-side-slot '(0 0 0 0) 'bottom)
+                 '(0 0 0 1))))
+
+(ert-deftest vulpea-ui-test-ensure-side-slot-keeps-positive ()
+  "A side that already allows slots is left untouched."
+  (should (equal (vulpea-ui--ensure-side-slot '(1 2 3 4) 'right)
+                 '(1 2 3 4))))
+
+(ert-deftest vulpea-ui-test-ensure-side-slot-keeps-unlimited ()
+  "A nil (unlimited) side is left untouched."
+  (should (equal (vulpea-ui--ensure-side-slot '(nil nil nil nil) 'right)
+                 '(nil nil nil nil))))
+
+(ert-deftest vulpea-ui-test-ensure-side-slot-does-not-mutate ()
+  "The original list is not modified in place."
+  (let ((slots (list 1 0 0 1)))
+    (vulpea-ui--ensure-side-slot slots 'right)
+    (should (equal slots '(1 0 0 1)))))
+
+(ert-deftest vulpea-ui-test-create-sidebar-window-when-side-disabled ()
+  "Sidebar window is created even when its side is disabled.
+With `window-sides-slots' forbidding side windows on the configured
+side, `vulpea-ui--create-sidebar-window' must still produce a real
+side window rather than returning nil (see vulpea-journal#21)."
+  (let ((window-sides-slots '(1 0 0 1))   ; right side disabled
+        (vulpea-ui-sidebar-position 'right))
+    (save-window-excursion
+      (let* ((buf (get-buffer-create " *vulpea-ui-test-sidebar*"))
+             (win (vulpea-ui--create-sidebar-window buf)))
+        (unwind-protect
+            (progn
+              (should (window-live-p win))
+              (should (eq (window-parameter win 'window-side) 'right)))
+          (when (window-live-p win) (ignore-errors (delete-window win)))
+          (when (buffer-live-p buf) (kill-buffer buf)))))))
+
+
 ;;; Number formatting tests
 
 (ert-deftest vulpea-ui-test-format-number-small ()

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -376,9 +376,35 @@ If FRAME is nil, use the selected frame."
                             (dedicated . t)
                             (no-other-window . nil))))))
 
+(defun vulpea-ui--ensure-side-slot (slots side)
+  "Return SLOTS with SIDE guaranteed at least one available slot.
+SLOTS is a value shaped like `window-sides-slots': a list of four
+elements limiting the number of side windows on the left, top, right
+and bottom of a frame.  A nil element means an unlimited number of
+slots and is left untouched.  A numeric element below one is raised to
+one so `display-buffer-in-side-window' will not refuse to create the
+sidebar window.  SIDE is one of `left', `top', `right' or `bottom'.
+The input SLOTS is not modified."
+  (let ((idx (pcase side
+               ('left 0) ('top 1) ('right 2) ('bottom 3)
+               (_ (error "Invalid side: %S" side))))
+        (slots (copy-sequence slots)))
+    (let ((cur (nth idx slots)))
+      (when (and (numberp cur) (< cur 1))
+        (setf (nth idx slots) 1)))
+    slots))
+
 (defun vulpea-ui--create-sidebar-window (buffer)
-  "Create a sidebar window for BUFFER using side window mechanics."
-  (display-buffer-in-side-window buffer (vulpea-ui--display-buffer-params)))
+  "Create a sidebar window for BUFFER using side window mechanics.
+The configured side is guaranteed at least one slot in a local copy of
+`window-sides-slots', so the sidebar is still displayed when the user
+has disabled side windows on that side.  Otherwise
+`display-buffer-in-side-window' would return nil and the sidebar
+buffer would clobber the selected window."
+  (let ((window-sides-slots
+         (vulpea-ui--ensure-side-slot window-sides-slots
+                                      vulpea-ui-sidebar-position)))
+    (display-buffer-in-side-window buffer (vulpea-ui--display-buffer-params))))
 
 (defun vulpea-ui--get-main-window (&optional frame)
   "Get the most recently used non-sidebar window in FRAME."


### PR DESCRIPTION
## What

Bind a local copy of `window-sides-slots` in `vulpea-ui--create-sidebar-window` that guarantees the sidebar's configured side at least one slot, so `display-buffer-in-side-window` always produces a real side window.

A new pure helper `vulpea-ui--ensure-side-slot` raises a numeric, sub-one slot count for the chosen side to 1 while leaving `nil` (unlimited) and already-positive entries untouched.

## Why

When a user disables side windows on the sidebar's side via `window-sides-slots` (e.g. `'(1 0 0 1)` to forbid right-side windows), `display-buffer-in-side-window` returns `nil` and no window is created. The downstream render path then runs `vui-mount`'s `switch-to-buffer` in the currently selected window, so the sidebar buffer silently replaces the main buffer, and a follow-up auto-hide attempts `delete-window` on the now-sole window — surfacing the errors reported in [d12frosted/vulpea-journal#21](https://github.com/d12frosted/vulpea-journal/issues/21):

> Attempt to delete minibuffer or sole ordinary window
> Attempt to delete main window of frame ...

This is the root-cause fix. Two follow-up PRs will harden the teardown and render paths as defense-in-depth.

Refs d12frosted/vulpea-journal#21