### PR TITLE
fix: improve docstring and customize type for vulpea-ui-sidebar-size

### DIFF
--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -74,11 +74,12 @@ One of `left', `right', `top', or `bottom'."
   :group 'vulpea-ui)
 
 (defcustom vulpea-ui-sidebar-size 0.33
-  "Width of the sidebar when `vulpea-ui-sidebar-position' is \\='left or
-\\='right. Or height of the sidebar if `vulpea-ui-sidebar-position' is
-\\='top or \\='bottom. It can be an integer, a floating-point number,
-and more. See entries 'window-height' and 'window-width' of Info
-node `(elisp) Buffer Display Action Alists'."
+  "Size of the sidebar window.
+This is the width when `vulpea-ui-sidebar-position' is \\='left or
+\\='right, or the height when it is \\='top or \\='bottom.  It can be an
+integer, a floating-point number, and more.  See entries
+`window-height' and `window-width' of Info node `(elisp) Buffer
+Display Action Alists'."
   :type '(choice (float :tag "Fraction of frame (0.0-1.0)")
                  (integer :tag "Total lines or columns")
                  (cons :tag "Body size"

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -74,10 +74,17 @@ One of `left', `right', `top', or `bottom'."
   :group 'vulpea-ui)
 
 (defcustom vulpea-ui-sidebar-size 0.33
-  "Size of the sidebar as a fraction of the frame.
-A float between 0.0 and 1.0 representing the fraction of frame
-width (for left/right position) or height (for top/bottom position)."
-  :type 'float
+  "Width of the sidebar when `vulpea-ui-sidebar-position' is \\='left or
+\\='right. Or height of the sidebar if `vulpea-ui-sidebar-position' is
+\\='top or \\='bottom. It can be an integer, a floating-point number,
+and more. See entries 'window-height' and 'window-width' of Info
+node `(elisp) Buffer Display Action Alists'."
+  :type '(choice (float :tag "Fraction of frame (0.0-1.0)")
+                 (integer :tag "Total lines or columns")
+                 (cons :tag "Body size"
+                       (choice (const body-lines) (const body-columns))
+                       integer)
+                 (function :tag "Window-adjusting function"))
   :group 'vulpea-ui)
 
 (defcustom vulpea-ui-default-widget-collapsed nil


### PR DESCRIPTION
Improve the docstring and customize type for vulpea-ui-sidebar-size to better reveal its full potential. Also point users to read the Elisp Info documentation about Buffer Display Action Alists.

Simply combine the docstring I proposed and the customize type specification by @d12frosted in #41 