### PR TITLE
Report schema health for every note in the file

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 * Unreleased
 
+** Added
+
+- The schema health widget now reports on *every* note in the file, not just the one the sidebar is anchored on. A heading with its own =:ID:=, tags and metadata is a note in its own right, so a file often holds several: the file-level note plus one per heading. With a single schema-bearing note the widget reads exactly as before; with several it breaks the file down per note - the file-level note first, then headings in document order - each violated note under its title (a keyed button that jumps to it), with a trailing =✓ N notes healthy= count for the clean ones. Each violation's =fix= button writes back into *that* note (a heading's field lands in the heading's subtree, via vulpea's =bound= argument), and the buttons carry note-scoped keys so point rides its row across a fix even when notes above it clear. The widget hides only when no note in the file bears a schema.
+
+- Support files whose IDs live only on headings. =vulpea-ui--get-note-from-buffer= now falls back to the earliest heading-level note (by position) when a file has no file-level =:ID:=, so heading-only files anchor the sidebar and light up the schema widget instead of showing nothing. Files that do have a file-level ID are unaffected.
+
+- =vulpea-ui-schema-health-note-face= (inherits =bold=) for a note's title in the per-file breakdown.
+
+** Fixed
+
+- The schema health widget and the schema dashboard now jump to the right line for a field that fails =:one-of= on more than one of its values. =vulpea-ui--schema-violation-position= matched on the field name alone, so each disallowed value of a multi-value field jumped to that field's *first* line; it now prefers the line carrying the offending value, falling back to the first occurrence when the value cannot be matched textually.
+
+- The schema health widget was blind to heading-level notes: it always resolved the file-level note and reported only that one's schema, so a violation on an =:execution:= heading inside a schema-less =:journal:= file was invisible in the sidebar (the counterpart, on the authoring side, to [[https://github.com/d12frosted/vulpea/issues/356][vulpea#356]]). It now looks at the whole file, so heading violations surface regardless of where point sits. The lower-level scoping helpers (=vulpea-ui--schema-note-end=, =-meta-position=, =-violation-position=) were already heading-aware but had never been exercised on a heading; they now have coverage.
+
 * v1.2.0 (2026-07-02)
 
 ** Added

--- a/README.org
+++ b/README.org
@@ -251,13 +251,15 @@ Shows character count, word count, and link count for the current note.
 </p>
 #+end_html
 
-Flags how the current note measures up to the vulpea schema(s) that apply
-to it: a green =healthy= line when it conforms, or its violations
-otherwise - a severity-coloured bullet (red for structural problems,
-amber for value problems), the field, and a terse reason. Each violation
-has a =fix= button that prompts for a corrected value and writes it back,
-and the field name jumps to it in the note. Shown only when a schema
-applies.
+Flags how the notes in the current file measure up to their vulpea
+schema(s) - every note in the file, the file-level note and each
+heading-level note. A single schema-bearing note shows a green =healthy=
+line or its violations (a severity-coloured bullet - red for structural
+problems, amber for value problems - the field, and a terse reason);
+several are broken down per note, each under its title, so a heading's
+violation is never hidden behind a schema-less =:journal:= file. Each
+violation's =fix= button prompts for a value and writes it back into that
+note. Shown only when some note in the file bears a schema.
 
 ** Outline widget
 

--- a/README.org
+++ b/README.org
@@ -94,12 +94,25 @@ To automatically open the sidebar when entering org-mode buffers:
 
 ** Schema health widget
 
-Flags how the current note measures up to the vulpea schema(s) that apply
-to it: nothing unless a schema applies, a green =healthy= line when the
-note conforms, or the list of violations otherwise. Each violation has a
-=fix= button that prompts for a corrected value and writes it back, and
-the field name jumps to it in the note. Needs a vulpea with the schema
-validation engine (the =fix= button needs =vulpea-schema-fix-violation=).
+Flags how the notes in the current file measure up to the vulpea
+schema(s) that apply to them - and that means every note in the file, the
+file-level note *and* each heading-level note, not just whichever one the
+sidebar is anchored on. A file can hold several notes (a heading with its
+own =:ID:=, tags and metadata is a note in its own right), so an
+=:execution:= heading's missing field is no longer hidden behind a
+schema-less =:journal:= file.
+
+With a single schema-bearing note it reads as one status: nothing unless
+a schema applies, a green =healthy= line when it conforms, or its
+violations otherwise. With several it breaks the file down per note - the
+file-level note first, then headings in document order - each violated
+note under its title (click it to jump there), with a trailing count for
+any notes that are clean. Each violation has a =fix= button that prompts
+for a corrected value and writes it back *into that note* (a heading's
+field lands in the heading, not the top of the file), and the field name
+jumps to it. Files whose IDs live only on headings work too. Needs a
+vulpea with the schema validation engine (the =fix= button needs
+=vulpea-schema-fix-violation=).
 
 #+begin_src emacs-lisp
 ;; Glyphs - portable text by default; swap in nerd-font / all-the-icons
@@ -110,9 +123,9 @@ validation engine (the =fix= button needs =vulpea-schema-fix-violation=).
 #+end_src
 
 The faces =vulpea-ui-schema-health-ok-face= / =-error-face= /
-=-warning-face= / =-field-face= / =-message-face= / =-action-face= inherit
-=success= / =error= / =warning= / =bold= / =shadow= / =link=, so they
-follow your theme.
+=-warning-face= / =-field-face= / =-message-face= / =-action-face= /
+=-note-face= inherit =success= / =error= / =warning= / =bold= / =shadow= /
+=link= / =bold=, so they follow your theme.
 
 ** Backlinks widget
 

--- a/test/vulpea-ui-test.el
+++ b/test/vulpea-ui-test.el
@@ -1181,9 +1181,9 @@ unlinked-mentions widget for the duration of the render."
     (vulpea-schema-define 'wine
       :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
       :fields '((:key "name" :required t)))
-    (should-not (vulpea-ui--schema-health
+    (should-not (vulpea-ui--schema-note-health
                  (make-vulpea-note :id "b" :title "B" :tags '("beer"))))
-    (should-not (vulpea-ui--schema-health nil))))
+    (should-not (vulpea-ui--schema-note-health nil))))
 
 (ert-deftest vulpea-ui-test-schema-health-conformant ()
   "A conformant note reports its schema and no violations."
@@ -1191,7 +1191,7 @@ unlinked-mentions widget for the duration of the render."
     (vulpea-schema-define 'wine
       :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
       :fields '((:key "name" :required t)))
-    (let ((h (vulpea-ui--schema-health
+    (let ((h (vulpea-ui--schema-note-health
               (make-vulpea-note :id "w" :title "W" :tags '("wine")
                                 :meta '(("name" "Chablis"))))))
       (should (equal (plist-get h :schemas) '(wine)))
@@ -1204,7 +1204,7 @@ unlinked-mentions widget for the duration of the render."
       :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
       :fields '((:key "name" :required t)
                 (:key "colour" :type symbol :one-of (red white))))
-    (let* ((h (vulpea-ui--schema-health
+    (let* ((h (vulpea-ui--schema-note-health
                (make-vulpea-note :id "w" :title "W" :tags '("wine")
                                  :meta '(("colour" "blue")))))
            (vs (plist-get h :violations)))
@@ -1895,6 +1895,686 @@ the fixed note first, so vui recovers to the previous note instead."
                              (list 'wine "beta")))))
         (when (get-buffer bufname) (kill-buffer bufname))
         (when (get-buffer "*fix-note*") (kill-buffer "*fix-note*"))))))
+
+;;; Schema - heading-level notes
+
+;; The file-level schema tests above never exercise a heading-level note
+;; (every fixture is `:level 0').  These cover the heading paths - the
+;; same class of scoping that vulpea#356/#357 fixed in vulpea itself:
+;; scope must be the heading's subtree, not the whole file.
+
+(defmacro vulpea-ui-test--with-heading-note (meta &rest body)
+  "Visit a file whose FILE-level note is not wine but which holds a wine
+HEADING; bind NOTE to that heading (level-1, META) and BUF.
+
+The fixture is shaped like vulpea#356: a `journal' file with a `* Wine
+:wine:' heading, a trailing sibling heading so the subtree end differs
+from `point-max', and a file-level meta line so a file-scoped bug is
+visible.  Registers a `wine' schema requiring `name', constraining
+`colour'."
+  (declare (indent 1))
+  `(let ((vulpea-schema--registry (make-hash-table :test 'eq))
+         (file (make-temp-file "vulpea-ui-schema-h-" nil ".org")))
+     (unwind-protect
+         (progn
+           (with-temp-file file
+             (insert ":PROPERTIES:\n:ID: file-1\n:END:\n"
+                     "#+title: Journal\n#+filetags: :journal:\n\n"
+                     "- note :: file level meta\n\n"
+                     "* Wine :wine:\n"
+                     ":PROPERTIES:\n:ID: w-head\n:END:\n"
+                     "- colour :: blue\n\n"
+                     "* Other :misc:\ntrailing text\n"))
+           (vulpea-schema-define 'wine
+             :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
+             :fields '((:key "name" :required t)
+                       (:key "colour" :type symbol :one-of (red white))))
+           (let* ((buf (find-file-noselect file))
+                  (pos (with-current-buffer buf
+                         (save-excursion
+                           (goto-char (point-min))
+                           (re-search-forward "^\\* Wine")
+                           (line-beginning-position))))
+                  (note (make-vulpea-note :id "w-head" :title "Wine" :path file
+                                          :level 1 :pos pos :tags '("wine")
+                                          :meta ,meta)))
+             (unwind-protect (progn ,@body) (kill-buffer buf))))
+       (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-schema-note-end-heading ()
+  "A heading note's scope ends at its subtree, not `point-max'."
+  (vulpea-ui-test--with-heading-note '(("colour" "blue"))
+    (with-current-buffer buf
+      (let ((end (vulpea-ui--schema-note-end note)))
+        (should (> end (vulpea-note-pos note)))
+        (should (< end (point-max)))
+        (let ((sub (buffer-substring-no-properties (vulpea-note-pos note) end)))
+          (should (string-match-p "colour :: blue" sub))
+          (should-not (string-match-p "trailing text" sub)))))))
+
+(ert-deftest vulpea-ui-test-schema-meta-position-heading ()
+  "Metadata resolves to the heading's own meta, below its heading line."
+  (vulpea-ui-test--with-heading-note '(("colour" "blue"))
+    (with-current-buffer buf
+      (goto-char (vulpea-ui--schema-meta-position note))
+      (should (looking-at-p "^- colour ::"))
+      (should (> (point) (vulpea-note-pos note))))))
+
+(ert-deftest vulpea-ui-test-schema-violation-position-heading-missing ()
+  "A missing field on a heading lands inside its subtree, not the file top."
+  (vulpea-ui-test--with-heading-note '(("colour" "blue"))
+    (with-current-buffer buf
+      (let ((pos (vulpea-ui--schema-violation-position
+                  (vulpea-ui-test--wine-violation note "name") note)))
+        (should (>= pos (vulpea-note-pos note)))
+        (should (< pos (vulpea-ui--schema-note-end note)))
+        (goto-char pos)
+        (should (looking-at-p "^- colour ::"))))))
+
+(ert-deftest vulpea-ui-test-schema-violation-position-heading-value ()
+  "A value violation on a heading points at that heading's field line."
+  (vulpea-ui-test--with-heading-note '(("colour" "blue"))
+    (with-current-buffer buf
+      (goto-char (vulpea-ui--schema-violation-position
+                  (vulpea-ui-test--wine-violation note "colour") note))
+      (should (looking-at-p "^- colour ::"))
+      (should (> (point) (vulpea-note-pos note))))))
+
+(ert-deftest vulpea-ui-test-schema-note-end-stops-before-child ()
+  "A heading's section ends at its first child, not at the subtree end.
+Metadata under a child heading belongs to the child note, so it must be
+out of the parent's scope."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq))
+        (file (make-temp-file "vulpea-ui-nested-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert ":PROPERTIES:\n:ID: file-1\n:END:\n#+title: J\n\n"
+                    "* Wine :wine:\n:PROPERTIES:\n:ID: w\n:END:\n"
+                    "** Child\n- foo :: bar\n"))
+          (vulpea-schema-define 'wine :predicate (lambda (_n) t)
+            :fields '((:key "name" :required t)))
+          (let* ((buf (find-file-noselect file))
+                 (wpos (with-current-buffer buf
+                         (save-excursion (goto-char (point-min))
+                                         (re-search-forward "^\\* Wine")
+                                         (line-beginning-position))))
+                 (cpos (with-current-buffer buf
+                         (save-excursion (goto-char (point-min))
+                                         (re-search-forward "^\\*\\* Child")
+                                         (line-beginning-position))))
+                 (note (make-vulpea-note :id "w" :title "Wine" :path file
+                                         :level 1 :pos wpos :tags '("wine"))))
+            (unwind-protect
+                (with-current-buffer buf
+                  ;; scope ends at the child heading, excluding its meta
+                  (should (<= (vulpea-ui--schema-note-end note) cpos))
+                  ;; a missing field lands in the parent's own section, at
+                  ;; or before the child boundary - never on the child's
+                  ;; "- foo :: bar"
+                  (let ((pos (vulpea-ui--schema-violation-position
+                              (vulpea-ui-test--wine-violation note "name") note)))
+                    (should (>= pos (vulpea-note-pos note)))
+                    (should (<= pos cpos))
+                    (goto-char pos)
+                    (should-not (looking-at-p "^- foo"))))
+              (kill-buffer buf))))
+      (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-schema-fix-violation-action-heading-writes ()
+  "Fixing a heading note's missing field writes INTO the heading.
+The vulpea-ui#356 analog: the field must land below the `* Wine'
+heading and above the next heading, never at the top of the file."
+  (skip-unless (fboundp 'vulpea-schema-fix-violation))
+  (vulpea-ui-test--with-heading-note '(("colour" "blue"))
+    (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "Chateau Test"))
+              ((symbol-function 'vulpea-db-update-file) #'ignore)
+              ((symbol-function 'vulpea-ui-sidebar-refresh) #'ignore))
+      (vulpea-ui--schema-fix-violation-action
+       note (vulpea-ui-test--wine-violation note "name"))
+      (with-current-buffer buf
+        (let* ((body (buffer-string))
+               (name-at (string-match "^- name :: Chateau Test" body))
+               (wine-at (string-match "^\\* Wine" body))
+               (other-at (string-match "^\\* Other" body)))
+          (should name-at)
+          (should (> name-at wine-at))
+          (should (< name-at other-at)))))))
+
+(ert-deftest vulpea-ui-test-schema-dashboard-fix-heading-writes ()
+  "Fixing a heading note's missing field from the dashboard writes INTO it."
+  (skip-unless (fboundp 'vulpea-schema-fix-violation))
+  (vulpea-ui-test--with-heading-note '(("colour" "blue"))
+    (cl-letf (((symbol-function 'pop-to-buffer) #'ignore)
+              ((symbol-function 'read-string) (lambda (&rest _) "Chateau Test"))
+              ((symbol-function 'vulpea-db-update-file) #'ignore)
+              ((symbol-function 'vulpea-ui-schema-dashboard-refresh) #'ignore))
+      (vulpea-ui-schema-dashboard--fix-violation
+       note (vulpea-ui-test--wine-violation note "name"))
+      (with-current-buffer buf
+        (let* ((body (buffer-string))
+               (name-at (string-match "^- name :: Chateau Test" body))
+               (wine-at (string-match "^\\* Wine" body))
+               (other-at (string-match "^\\* Other" body)))
+          (should name-at)
+          (should (> name-at wine-at))
+          (should (< name-at other-at)))))))
+
+(ert-deftest vulpea-ui-test-schema-sidebar-tracks-file-level ()
+  "The sidebar anchors on the FILE-level note, even with point on a heading.
+`vulpea-ui--get-note-from-buffer' reads the file-level ID regardless of
+point, so the whole-file widgets (outline, backlinks, stats) stay
+file-scoped.  The schema widget is no longer limited to that one note -
+it breaks the whole file down from this note's path (see the per-file
+breakdown tests) - but the sidebar's anchor is still the file note."
+  (vulpea-ui-test--with-heading-note '(("colour" "blue"))
+    (cl-letf (((symbol-function 'vulpea-db-get-by-id)
+               (lambda (id) (make-vulpea-note :id id :title id))))
+      (with-current-buffer buf
+        (goto-char (vulpea-note-pos note))
+        (forward-line 2)
+        (let ((shown (vulpea-ui--get-note-from-buffer buf)))
+          (should (equal (vulpea-note-id shown) "file-1"))
+          (should-not (equal (vulpea-note-id shown) "w-head")))))))
+
+;;; Schema - per-file breakdown (file + heading notes)
+
+;; The schema widget reports on every note in the file, not just the one
+;; anchoring the sidebar.  These cover the data layer (pure), the render
+;; (single vs multi-note), the heading-only-file anchor, and the keyed
+;; cursor identity that keeps point put across a fix.
+
+(defmacro vulpea-ui-test--with-wine-schema (&rest body)
+  "Run BODY with a fresh registry holding a `wine' schema.
+`wine' applies to notes tagged \"wine\", requires `name', constrains
+`colour' to red/white."
+  (declare (indent 0))
+  `(let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+     (vulpea-schema-define 'wine
+       :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
+       :fields '((:key "name" :required t)
+                 (:key "colour" :type symbol :one-of (red white))))
+     ,@body))
+
+(defun vulpea-ui-test--wnote (id title pos level &optional tags meta)
+  "A note at POS/LEVEL tagged TAGS (default wine) with META, in /tmp/wf.org."
+  (make-vulpea-note :id id :title title :path "/tmp/wf.org"
+                    :level level :pos pos
+                    :tags (or tags '("wine")) :meta meta))
+
+;; --- data layer: vulpea-ui--schema-file-health (pure) -----------------
+
+(ert-deftest vulpea-ui-test-schema-file-health-empty ()
+  "No notes yields an empty, zero-count breakdown."
+  (let ((h (vulpea-ui--schema-file-health nil)))
+    (should-not (plist-get h :entries))
+    (should-not (plist-get h :violated))
+    (should (= (plist-get h :healthy-count) 0))
+    (should (= (plist-get h :issue-count) 0))))
+
+(ert-deftest vulpea-ui-test-schema-file-health-filters-non-schema ()
+  "Notes no schema applies to are dropped from the breakdown."
+  (vulpea-ui-test--with-wine-schema
+    (let* ((wine (vulpea-ui-test--wnote "w" "Wine" 1 0 '("wine") '(("name" "A"))))
+           (misc (vulpea-ui-test--wnote "m" "Misc" 40 1 '("misc")))
+           (h (vulpea-ui--schema-file-health (list wine misc)))
+           (entries (plist-get h :entries)))
+      (should (= (length entries) 1))
+      (should (equal (vulpea-note-id (plist-get (car entries) :note)) "w")))))
+
+(ert-deftest vulpea-ui-test-schema-file-health-sorts-by-pos ()
+  "Entries are ordered by buffer position: file-level note first."
+  (vulpea-ui-test--with-wine-schema
+    (let* ((h2 (vulpea-ui-test--wnote "h2" "White" 80 1 '("wine") nil))
+           (file (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine") nil))
+           (h1 (vulpea-ui-test--wnote "h1" "Red" 40 1 '("wine") nil))
+           ;; Deliberately out of order on input.
+           (h (vulpea-ui--schema-file-health (list h2 file h1)))
+           (titles (mapcar (lambda (e) (vulpea-note-title (plist-get e :note)))
+                           (plist-get h :entries))))
+      (should (equal titles '("Cellar" "Red" "White"))))))
+
+(ert-deftest vulpea-ui-test-schema-file-health-counts ()
+  "Violated, healthy-count and issue-count reflect the whole file."
+  (vulpea-ui-test--with-wine-schema
+    (let* ((file (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine")
+                                        '(("name" "C") ("colour" "red"))))
+           (h1 (vulpea-ui-test--wnote "h1" "Red" 40 1 '("wine") nil)) ; miss name
+           (h2 (vulpea-ui-test--wnote "h2" "Blue" 80 1 '("wine")
+                                      '(("colour" "blue"))))          ; miss name + bad colour
+           (h (vulpea-ui--schema-file-health (list file h1 h2))))
+      (should (= (length (plist-get h :entries)) 3))
+      (should (= (length (plist-get h :violated)) 2))
+      (should (= (plist-get h :healthy-count) 1))
+      (should (= (plist-get h :issue-count) 3))
+      ;; violated stays in document order
+      (should (equal (mapcar (lambda (e) (vulpea-note-title (plist-get e :note)))
+                             (plist-get h :violated))
+                     '("Red" "Blue"))))))
+
+(ert-deftest vulpea-ui-test-schema-file-health-multi-schema-note ()
+  "A note matching two schemas reports both, with the union of violations."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq)))
+    (vulpea-schema-define 'wine
+      :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
+      :fields '((:key "name" :required t)))
+    (vulpea-schema-define 'producer
+      :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
+      :fields '((:key "region" :required t)))
+    (let* ((note (vulpea-ui-test--wnote "w" "Wine" 1 0 '("wine") nil))
+           (h (vulpea-ui--schema-file-health (list note)))
+           (entry (car (plist-get h :entries)))
+           (schemas (plist-get entry :schemas)))
+      (should (memq 'wine schemas))
+      (should (memq 'producer schemas))
+      (should (= (plist-get h :issue-count) 2)))))
+
+;; --- data layer: vulpea-ui--schema-file-notes (DB wrapper) ------------
+
+(ert-deftest vulpea-ui-test-schema-file-notes-query ()
+  "The file-notes wrapper passes the path to the DB and returns its rows."
+  (let ((seen nil)
+        (rows (list (vulpea-ui-test--wnote "a" "A" 1 0))))
+    (cl-letf (((symbol-function 'vulpea-db-query-by-file-path)
+               (lambda (path &rest _) (setq seen path) rows)))
+      (should (eq (vulpea-ui--schema-file-notes "/tmp/wf.org") rows))
+      (should (equal seen "/tmp/wf.org"))
+      ;; nil path never touches the DB
+      (setq seen 'untouched)
+      (should-not (vulpea-ui--schema-file-notes nil))
+      (should (eq seen 'untouched)))))
+
+;; --- render: mount the widget over a mocked file query ----------------
+
+(vui-defcomponent vulpea-ui-test--schema-harness (note)
+  "Mount only the schema-health widget under NOTE's context."
+  :render
+  (vulpea-ui-note-provider note
+    (vui-component 'vulpea-ui-widget-schema-health)))
+
+(defmacro vulpea-ui-test--with-schema-widget (notes anchor &rest body)
+  "Mount the schema widget over NOTES (the mocked file-path query) with
+ANCHOR as the sidebar note; run BODY in the widget buffer with the mount
+INSTANCE bound.  A `wine' schema is registered."
+  (declare (indent 2))
+  `(vulpea-ui-test--with-wine-schema
+     (let ((vui-render-delay nil)
+           (bufname "*vulpea-ui schema widget test*"))
+       (cl-letf (((symbol-function 'vulpea-db-query-by-file-path)
+                  (lambda (&rest _) ,notes)))
+         (unwind-protect
+             (let ((instance
+                    (vui-mount (vui-component 'vulpea-ui-test--schema-harness
+                                              :note ,anchor)
+                               bufname)))
+               (ignore instance)
+               (with-current-buffer bufname ,@body))
+           (when (get-buffer bufname) (kill-buffer bufname)))))))
+
+(ert-deftest vulpea-ui-test-schema-widget-single-note ()
+  "One schema note in the file renders the classic per-note view."
+  (let ((note (vulpea-ui-test--wnote "w" "Wine" 1 0 '("wine")
+                                     '(("colour" "blue")))))
+    (vulpea-ui-test--with-schema-widget (list note) note
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        (should (string-match-p "Schema" text))
+        (should (string-match-p "wine ·" text))       ; schema-name line
+        (should (string-match-p "name" text))          ; the missing field
+        (should-not (string-match-p "notes ·" text)))))) ; no multi summary
+
+(ert-deftest vulpea-ui-test-schema-widget-multi-breakdown ()
+  "File + violated headings render a per-note breakdown with titles."
+  (let ((file (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine")
+                                     '(("name" "C") ("colour" "red"))))
+        (h1 (vulpea-ui-test--wnote "h1" "Red" 40 1 '("wine") nil))
+        (h2 (vulpea-ui-test--wnote "h2" "Blue" 80 1 '("wine")
+                                   '(("colour" "blue")))))
+    (vulpea-ui-test--with-schema-widget (list file h1 h2)
+        (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine")
+                               '(("name" "C") ("colour" "red")))
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        (should (string-match-p "2 notes · 3 issues" text))
+        (should (string-match-p "Red" text))            ; violated heading title
+        (should (string-match-p "Blue" text))           ; violated heading title
+        (should (string-match-p "1 note healthy" text)) ; the clean file note
+        (should-not (string-match-p "Cellar" text))))))  ; healthy note not expanded
+
+(ert-deftest vulpea-ui-test-schema-widget-all-healthy ()
+  "Several notes, all conformant, collapse to a healthy summary."
+  (let ((file (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine")
+                                     '(("name" "C"))))
+        (h1 (vulpea-ui-test--wnote "h1" "Red" 40 1 '("wine")
+                                   '(("name" "R")))))
+    (vulpea-ui-test--with-schema-widget (list file h1)
+        (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine") '(("name" "C")))
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        (should (string-match-p "2 notes · healthy" text))
+        (should-not (string-match-p "issue" text))))))
+
+(ert-deftest vulpea-ui-test-schema-widget-hidden-when-no-schema ()
+  "A file with no schema-bearing note renders nothing."
+  (let ((note (vulpea-ui-test--wnote "m" "Misc" 1 0 '("misc"))))
+    (vulpea-ui-test--with-schema-widget (list note) note
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        (should-not (string-match-p "Schema" text))))))
+
+(ert-deftest vulpea-ui-test-schema-widget-heading-titles-are-buttons ()
+  "Each violated note title is a keyed jump button; violation buttons too."
+  (let ((file (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine")
+                                     '(("name" "C") ("colour" "red"))))
+        (h1 (vulpea-ui-test--wnote "h1" "Red" 40 1 '("wine") nil))
+        (h2 (vulpea-ui-test--wnote "h2" "Blue" 80 1 '("wine") nil)))
+    (vulpea-ui-test--with-schema-widget (list file h1 h2)
+        (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine")
+                               '(("name" "C") ("colour" "red")))
+      (let ((keys (mapcar (lambda (w) (vui-element-get w :vui-key))
+                          (vui--collect-widgets))))
+        ;; per-note title buttons
+        (should (member (list 'schema-note "h1") keys))
+        (should (member (list 'schema-note "h2") keys))
+        ;; field + fix buttons keyed by note-id / field / type / index
+        (should (member (list 'field "h1" "name" 'missing-required 0) keys))
+        (when (fboundp 'vulpea-schema-fix-violation)
+          (should (member (list 'fix "h1" "name" 'missing-required 0) keys)))
+        ;; every key unique (what a dropped note-id or index would break)
+        (let ((real (delq nil keys)))
+          (should (= (length real) (length (seq-uniq real #'equal)))))))))
+
+(ert-deftest vulpea-ui-test-schema-widget-cursor-survives-refresh ()
+  "Dropping a note above point keeps point on its own fix button.
+Only the note-id in the key keeps point from sliding to a same-labelled
+`fix' button on another note when the rows above it disappear."
+  (skip-unless (fboundp 'vulpea-schema-fix-violation))
+  (vulpea-ui-test--with-wine-schema
+    (let* ((vui-render-delay nil)
+           (bufname "*vulpea-ui schema widget test*")
+           (anchor (vulpea-ui-test--wnote "f" "Cellar" 1 0 '("wine")
+                                          '(("name" "C") ("colour" "red"))))
+           (h1 (vulpea-ui-test--wnote "h1" "Red" 40 1 '("wine") nil))
+           (h2 (vulpea-ui-test--wnote "h2" "Blue" 80 1 '("wine") nil))
+           (current (list anchor h1 h2)))
+      (cl-letf (((symbol-function 'vulpea-db-query-by-file-path)
+                 (lambda (&rest _) current)))
+        (unwind-protect
+            (let ((instance (vui-mount
+                             (vui-component 'vulpea-ui-test--schema-harness
+                                            :note anchor)
+                             bufname)))
+              (with-current-buffer bufname
+                (let ((target (list 'fix "h2" "name" 'missing-required 0)))
+                  ;; park point on h2's fix button
+                  (goto-char (car (vui--widget-bounds
+                                   (seq-find (lambda (w)
+                                               (equal (vui-element-get w :vui-key)
+                                                      target))
+                                             (vui--collect-widgets)))))
+                  ;; h1 vanishes; rows above h2 shrink.  Bump the refresh
+                  ;; generation so the widget's memo recomputes.
+                  (setq current (list anchor h2))
+                  (cl-incf vulpea-ui--refresh-generation)
+                  (vui-update instance (list :note anchor))
+                  ;; point still on h2's fix button, not h1's old slot
+                  (should (equal (vui-key-at) target)))))
+          (when (get-buffer bufname) (kill-buffer bufname)))))))
+
+;; --- note resolution: heading-only files ------------------------------
+
+(ert-deftest vulpea-ui-test-get-note-heading-only-file ()
+  "A file with no file-level ID anchors on its earliest heading note.
+Heading-only files (IDs only on headings) still light up the sidebar."
+  (let ((file (make-temp-file "vulpea-ui-honly-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert "#+title: No File ID\n\n"
+                    "* First :wine:\n:PROPERTIES:\n:ID: h1\n:END:\n"
+                    "* Second :wine:\n:PROPERTIES:\n:ID: h2\n:END:\n"))
+          (let ((buf (find-file-noselect file)))
+            (unwind-protect
+                (cl-letf (((symbol-function 'vulpea-db-query-by-file-path)
+                           ;; return out of order to prove the sort
+                           (lambda (&rest _)
+                             (list (make-vulpea-note :id "h2" :title "Second"
+                                                     :path file :level 1 :pos 60)
+                                   (make-vulpea-note :id "h1" :title "First"
+                                                     :path file :level 1 :pos 20)))))
+                  (let ((note (vulpea-ui--get-note-from-buffer buf)))
+                    (should note)
+                    (should (equal (vulpea-note-id note) "h1")))) ; earliest by pos
+              (kill-buffer buf))))
+      (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-get-note-file-level-unchanged ()
+  "A file WITH a file-level ID still resolves the file note, not a heading.
+The heading-only fallback must not disturb the common case."
+  (let ((file (make-temp-file "vulpea-ui-fid-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert ":PROPERTIES:\n:ID: file-1\n:END:\n#+title: Has ID\n\n"
+                    "* Head :wine:\n:PROPERTIES:\n:ID: h1\n:END:\n"))
+          (let ((buf (find-file-noselect file))
+                (queried nil))
+            (unwind-protect
+                (cl-letf (((symbol-function 'vulpea-db-get-by-id)
+                           (lambda (id) (make-vulpea-note :id id :title id)))
+                          ((symbol-function 'vulpea-db-query-by-file-path)
+                           (lambda (&rest _) (setq queried t) nil)))
+                  (let ((note (vulpea-ui--get-note-from-buffer buf)))
+                    (should (equal (vulpea-note-id note) "file-1"))
+                    (should-not queried)))  ; fallback never ran
+              (kill-buffer buf))))
+      (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-get-note-file-id-db-miss ()
+  "A file-level ID the DB has not indexed yet resolves to nil, not a heading.
+When a file carries a file-level =:ID:= but the DB lookup misses (a fresh
+or unsynced note), the resolver must return nil - never fall through to
+the heading query and mis-anchor the whole-file widgets on a heading."
+  (let ((file (make-temp-file "vulpea-ui-miss-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert ":PROPERTIES:\n:ID: file-1\n:END:\n#+title: Fresh\n\n"
+                    "* Head :wine:\n:PROPERTIES:\n:ID: h1\n:END:\n"))
+          (let ((buf (find-file-noselect file))
+                (fell-through nil))
+            (unwind-protect
+                (cl-letf (((symbol-function 'vulpea-db-get-by-id)
+                           (lambda (_id) nil)) ; DB has not caught up
+                          ((symbol-function 'vulpea-db-query-by-file-path)
+                           (lambda (&rest _)
+                             (setq fell-through t)
+                             (list (make-vulpea-note :id "h1" :title "Head"
+                                                     :path file :level 1 :pos 40)))))
+                  (should-not (vulpea-ui--get-note-from-buffer buf))
+                  (should-not fell-through))
+              (kill-buffer buf))))
+      (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-schema-violation-position-multi-value ()
+  "Two disallowed values of one field resolve to their own distinct lines.
+Without value-aware search both rows would jump to the first occurrence."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq))
+        (file (make-temp-file "vulpea-ui-mv-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert ":PROPERTIES:\n:ID: file-1\n:END:\n#+title: J\n\n"
+                    "* Wine :wine:\n:PROPERTIES:\n:ID: w\n:END:\n"
+                    "- name :: X\n- colour :: blue\n- colour :: green\n"))
+          (vulpea-schema-define 'wine :predicate (lambda (_n) t)
+            :fields '((:key "name" :required t)
+                      (:key "colour" :type symbol :one-of (red white))))
+          (let* ((buf (find-file-noselect file))
+                 (wpos (with-current-buffer buf
+                         (save-excursion (goto-char (point-min))
+                                         (re-search-forward "^\\* Wine")
+                                         (line-beginning-position))))
+                 (note (make-vulpea-note :id "w" :title "Wine" :path file
+                                         :level 1 :pos wpos :tags '("wine")
+                                         :meta '(("name" "X")
+                                                 ("colour" "blue" "green"))))
+                 (viols (seq-filter
+                         (lambda (v) (equal (vulpea-violation-field v) "colour"))
+                         (vulpea-schema-validate note 'wine)))
+                 (val (lambda (v) (format "%s" (vulpea-violation-value v))))
+                 (blue (cl-find "blue" viols :key val :test #'equal))
+                 (green (cl-find "green" viols :key val :test #'equal)))
+            (unwind-protect
+                (with-current-buffer buf
+                  (should (= (length viols) 2))
+                  (should blue) (should green)
+                  (let ((bpos (vulpea-ui--schema-violation-position blue note))
+                        (gpos (vulpea-ui--schema-violation-position green note)))
+                    (should-not (= bpos gpos))
+                    (goto-char bpos) (should (looking-at-p "^- colour :: blue"))
+                    (goto-char gpos) (should (looking-at-p "^- colour :: green"))))
+              (kill-buffer buf))))
+      (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-schema-heading-at-point-max ()
+  "A heading that ends the file: scope runs to `point-max', positions hold."
+  (let ((vulpea-schema--registry (make-hash-table :test 'eq))
+        (file (make-temp-file "vulpea-ui-eof-" nil ".org")))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert ":PROPERTIES:\n:ID: file-1\n:END:\n#+title: J\n\n"
+                    "* Wine :wine:\n:PROPERTIES:\n:ID: w\n:END:\n- colour :: blue\n"))
+          (vulpea-schema-define 'wine :predicate (lambda (_n) t)
+            :fields '((:key "name" :required t)
+                      (:key "colour" :type symbol :one-of (red white))))
+          (let* ((buf (find-file-noselect file))
+                 (wpos (with-current-buffer buf
+                         (save-excursion (goto-char (point-min))
+                                         (re-search-forward "^\\* Wine")
+                                         (line-beginning-position))))
+                 (note (make-vulpea-note :id "w" :title "Wine" :path file
+                                         :level 1 :pos wpos :tags '("wine")
+                                         :meta '(("colour" "blue")))))
+            (unwind-protect
+                (with-current-buffer buf
+                  (should (= (vulpea-ui--schema-note-end note) (point-max)))
+                  (goto-char (vulpea-ui--schema-violation-position
+                              (vulpea-ui-test--wine-violation note "colour") note))
+                  (should (looking-at-p "^- colour :: blue"))
+                  (let ((pos (vulpea-ui--schema-violation-position
+                              (vulpea-ui-test--wine-violation note "name") note)))
+                    (should (>= pos wpos))
+                    (should (<= pos (point-max)))))
+              (kill-buffer buf))))
+      (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-schema-widget-duplicate-titles ()
+  "Two headings sharing a title stay distinct: keys are the note id, not title."
+  (let ((h1 (vulpea-ui-test--wnote "id-1" "Red Wine" 40 1 '("wine") nil))
+        (h2 (vulpea-ui-test--wnote "id-2" "Red Wine" 80 1 '("wine") nil)))
+    (vulpea-ui-test--with-schema-widget (list h1 h2)
+        (vulpea-ui-test--wnote "id-1" "Red Wine" 40 1 '("wine") nil)
+      (let ((keys (mapcar (lambda (w) (vui-element-get w :vui-key))
+                          (vui--collect-widgets))))
+        (should (member (list 'schema-note "id-1") keys))
+        (should (member (list 'schema-note "id-2") keys))
+        (let ((real (delq nil keys)))
+          (should (= (length real) (length (seq-uniq real #'equal)))))))))
+
+;;; Schema - real database, end to end (the vulpea#356 shape)
+
+;; The tests above mock the file-path query.  These index a real journal
+;; file with two wine headings into a real temp DB and drive the whole
+;; chain - query, health, render, fix - the way it runs in anger.
+
+(defmacro vulpea-ui-test--with-indexed-wine-file (&rest body)
+  "Index a journal file with two wine headings into a real temp DB.
+Binds FILE (path), FILE-ID, RED-ID, WHITE-ID.  The file-level note is a
+`journal' (matching no schema); `Red Wine' is invalid (missing name, bad
+colour); `White Wine' is valid.  A `wine' schema is registered and the
+DB is live for BODY, then everything is torn down."
+  (declare (indent 0))
+  `(let* ((vulpea-schema--registry (make-hash-table :test 'eq))
+          (temp-db (make-temp-file "vulpea-ui-idb-" nil ".db"))
+          (vulpea-db-location temp-db)
+          (vulpea-db--connection nil)
+          (file (make-temp-file "vulpea-ui-idb-" nil ".org"))
+          (file-id "11111111-1111-1111-1111-111111111111")
+          (red-id "22222222-2222-2222-2222-222222222222")
+          (white-id "33333333-3333-3333-3333-333333333333"))
+     (unwind-protect
+         (progn
+           (vulpea-schema-define 'wine
+             :predicate (lambda (n) (member "wine" (vulpea-note-tags n)))
+             :fields '((:key "name" :required t)
+                       (:key "colour" :type symbol :one-of (red white))))
+           (with-temp-file file
+             (insert (format ":PROPERTIES:\n:ID: %s\n:END:\n" file-id)
+                     "#+title: Journal\n#+filetags: :journal:\n\n"
+                     (format "* Red Wine :wine:\n:PROPERTIES:\n:ID: %s\n:END:\n"
+                             red-id)
+                     "- colour :: blue\n\n"
+                     (format "* White Wine :wine:\n:PROPERTIES:\n:ID: %s\n:END:\n"
+                             white-id)
+                     "- name :: Chablis\n- colour :: white\n"))
+           (vulpea-db)
+           (cl-letf (((symbol-function 'lwarn) #'ignore))
+             (vulpea-db-update-file file))
+           ,@body)
+       (when vulpea-db--connection (vulpea-db-close))
+       (when (get-file-buffer file) (kill-buffer (get-file-buffer file)))
+       (when (file-exists-p temp-db) (delete-file temp-db))
+       (when (file-exists-p file) (delete-file file)))))
+
+(ert-deftest vulpea-ui-test-schema-real-db-indexes-headings ()
+  "The DB indexes the file-level note and both heading-level notes."
+  (vulpea-ui-test--with-indexed-wine-file
+    (let ((notes (vulpea-db-query-by-file-path file)))
+      (should (= (length notes) 3))
+      (should (equal (sort (mapcar #'vulpea-note-level notes) #'<) '(0 1 1))))))
+
+(ert-deftest vulpea-ui-test-schema-real-db-widget-breakdown ()
+  "Anchored on the journal note, the widget surfaces the heading issues.
+The journal file-level note matches no schema, yet the widget - keyed on
+its file, not on that one note - still reports the wine headings.  This
+is the vulpea#356 shape driven through the real widget and DB."
+  (vulpea-ui-test--with-indexed-wine-file
+    (let ((anchor (vulpea-db-get-by-id file-id))
+          (vui-render-delay nil)
+          (bufname "*vulpea-ui schema widget test*"))
+      (should (equal (vulpea-note-tags anchor) '("journal")))
+      (unwind-protect
+          (progn
+            (vui-mount (vui-component 'vulpea-ui-test--schema-harness :note anchor)
+                       bufname)
+            (with-current-buffer bufname
+              (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+                (should (string-match-p "1 note · 2 issues" text))
+                (should (string-match-p "Red Wine" text))
+                (should (string-match-p "1 note healthy" text))
+                (should-not (string-match-p "White Wine" text)))))
+        (when (get-buffer bufname) (kill-buffer bufname))))))
+
+(ert-deftest vulpea-ui-test-schema-real-db-fix-into-heading ()
+  "Fixing from the widget writes the field into the heading's subtree.
+Real DB, real fixer: `- name ::' must land between the two headings."
+  (skip-unless (fboundp 'vulpea-schema-fix-violation))
+  (vulpea-ui-test--with-indexed-wine-file
+    (let* ((red (vulpea-db-get-by-id red-id))
+           (viol (cl-find "name" (vulpea-schema-validate red 'wine)
+                          :key #'vulpea-violation-field :test #'equal)))
+      (cl-letf (((symbol-function 'read-string) (lambda (&rest _) "Chateau Real"))
+                ((symbol-function 'vulpea-ui-sidebar-refresh) #'ignore)
+                ((symbol-function 'lwarn) #'ignore))
+        (find-file-noselect file)
+        (vulpea-ui--schema-fix-violation-action red viol))
+      (with-current-buffer (find-file-noselect file)
+        (revert-buffer t t)
+        (let* ((body (buffer-string))
+               (name-at (string-match "^- name :: Chateau Real" body))
+               (red-at (string-match "^\\* Red Wine" body))
+               (white-at (string-match "^\\* White Wine" body)))
+          (should name-at)
+          (should (> name-at red-at))
+          (should (< name-at white-at)))))))
 
 (provide 'vulpea-ui-test)
 ;;; vulpea-ui-test.el ends here

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -2089,7 +2089,7 @@ Set it to a nerd-font or all-the-icons glyph if you prefer."
                   (file-path &optional level))
 
 (defun vulpea-ui--schema-note-health (note)
-  "Return schema health for a single NOTE, or nil when no schema applies.
+  "Return schema health for a single NOTE, or nil when no schema is applicable.
 The result is a plist with :note, :schemas (the applicable schema names)
 and :violations (a list of `vulpea-violation' across them)."
   (when note

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -478,16 +478,38 @@ shrank the note window (see vulpea-ui#36)."
   "The vulpea note currently being displayed in the sidebar.")
 
 (defun vulpea-ui--get-note-from-buffer (buffer)
-  "Get the vulpea note from BUFFER, or nil if not a vulpea note."
+  "Get the vulpea note anchoring the sidebar for BUFFER, or nil.
+Prefers the file-level note, regardless of the entry at point, so the
+whole-file widgets (outline, backlinks, stats) stay file-scoped.  When
+the file has no file-level ID - a heading-only file, where only
+headings carry IDs - falls back to the earliest heading-level note by
+position, so the sidebar still anchors on the file and the schema widget
+can report on its headings.  The fallback only runs when there is no
+file-level ID, so files with one behave exactly as before."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when (derived-mode-p 'org-mode)
-        ;; Always get the file-level ID, not the entry at point
-        (save-excursion
-          (goto-char (point-min))
-          (let ((id (org-entry-get nil "ID")))
-            (when id
-              (vulpea-db-get-by-id id))))))))
+        (let ((file-id (save-excursion
+                         (goto-char (point-min))
+                         (org-entry-get nil "ID"))))
+          (if file-id
+              ;; File has a file-level ID: resolve it, or nil when the DB
+              ;; has not caught up yet.  Never fall through to a heading -
+              ;; that would anchor the whole-file widgets on a heading and
+              ;; break their file scope.  The gate is the ID's presence in
+              ;; the buffer, not whether the DB currently resolves it.
+              (vulpea-db-get-by-id file-id)
+            ;; Heading-only file (IDs only on headings): anchor on the
+            ;; earliest note by position, so the sidebar still lights up.
+            ;; Match vulpea's stored path convention (`expand-file-name',
+            ;; not a truename) so the query finds the file's notes.
+            (when (and buffer-file-name
+                       (fboundp 'vulpea-db-query-by-file-path))
+              (car (sort (vulpea-db-query-by-file-path
+                          (expand-file-name buffer-file-name))
+                         (lambda (a b)
+                           (< (or (vulpea-note-pos a) 0)
+                              (or (vulpea-note-pos b) 0))))))))))))
 
 (defun vulpea-ui--should-update-p (note)
   "Return non-nil if sidebar should update for NOTE."
@@ -2058,15 +2080,53 @@ Set it to a nerd-font or all-the-icons glyph if you prefer."
   "Face for the quick-fix action buttons of schema violations."
   :group 'vulpea-ui)
 
-(defun vulpea-ui--schema-health (note)
-  "Return schema health for NOTE, or nil when no schema is applicable.
-The result is a plist with :schemas (the applicable schema names) and
-:violations (a list of `vulpea-violation' across them).  Returns nil
-when NOTE matches no registered schema, so the widget hides entirely."
+(defface vulpea-ui-schema-health-note-face
+  '((t :inherit bold))
+  "Face for a note's title in the schema widget's per-file breakdown."
+  :group 'vulpea-ui)
+
+(declare-function vulpea-db-query-by-file-path "vulpea-db-query"
+                  (file-path &optional level))
+
+(defun vulpea-ui--schema-note-health (note)
+  "Return schema health for a single NOTE, or nil when no schema applies.
+The result is a plist with :note, :schemas (the applicable schema names)
+and :violations (a list of `vulpea-violation' across them)."
   (when note
     (when-let* ((schemas (vulpea-schema-applicable note)))
-      (list :schemas schemas
+      (list :note note
+            :schemas schemas
             :violations (vulpea-schema-note-violations note)))))
+
+(defun vulpea-ui--schema-file-notes (path)
+  "Return every indexed note in the file at PATH, or nil.
+Includes the file-level note and all heading-level notes, so the schema
+widget can report on the whole file rather than only the note at point."
+  (when (and path (fboundp 'vulpea-db-query-by-file-path))
+    (vulpea-db-query-by-file-path path)))
+
+(defun vulpea-ui--schema-file-health (notes)
+  "Return a schema-health breakdown for NOTES (all notes in one file).
+Keeps only the notes a schema applies to, ordered by buffer position so
+the file-level note comes first and headings follow in document order.
+The result is a plist:
+  :entries       per-note health plists (see `vulpea-ui--schema-note-health')
+  :violated      the entries that carry violations, in the same order
+  :healthy-count number of schema-matching notes with no violations
+  :issue-count   total number of violations across every entry"
+  (let* ((entries (delq nil (mapcar #'vulpea-ui--schema-note-health notes)))
+         (entries (sort entries
+                        (lambda (a b)
+                          (< (or (vulpea-note-pos (plist-get a :note)) 0)
+                             (or (vulpea-note-pos (plist-get b :note)) 0)))))
+         (violated (seq-filter (lambda (e) (plist-get e :violations)) entries))
+         (issue-count (apply #'+ (mapcar (lambda (e)
+                                           (length (plist-get e :violations)))
+                                         entries))))
+    (list :entries entries
+          :violated violated
+          :healthy-count (- (length entries) (length violated))
+          :issue-count issue-count)))
 
 (defun vulpea-ui--schema-violation-severity (type)
   "Return `error' or `warning' for a violation of TYPE.
@@ -2113,12 +2173,25 @@ type - otherwise falls back to the violation's own message."
       (_ (or (vulpea-violation-message violation) "invalid")))))
 
 (defun vulpea-ui--schema-note-end (note)
-  "Return the end of NOTE's scope in the current buffer.
-Assumes the current buffer is NOTE's file."
+  "Return the end of NOTE's own section in the current buffer.
+This bounds where NOTE's metadata and fields can live: the file's zeroth
+section for a file-level note (up to its first heading), or a heading's
+body up to its first child heading otherwise.  It deliberately stops
+before any child heading - meta there belongs to the child note, not to
+NOTE - so a missing-field target never leaks into a sub-heading.  Assumes
+the current buffer is NOTE's file."
   (save-excursion
     (goto-char (vulpea-note-pos note))
     (if (> (vulpea-note-level note) 0)
-        (progn (org-end-of-subtree t t) (point))
+        ;; A heading's own section runs to its first child heading, or to
+        ;; the end of its subtree when it has none.  Every heading inside
+        ;; the subtree is necessarily a child (deeper), so the first one
+        ;; found after the heading line marks the section end.
+        (let ((subtree-end (save-excursion (org-end-of-subtree t t) (point))))
+          (forward-line 1)
+          (if (re-search-forward "^\\*+ " subtree-end t)
+              (line-beginning-position)
+            subtree-end))
       (if (re-search-forward "^\\*+ " nil t)
           (line-beginning-position)
         (point-max)))))
@@ -2150,32 +2223,53 @@ Returns NOTE's own position when its file is not visited."
 
 (defun vulpea-ui--schema-violation-position (violation note)
   "Return a position in NOTE's file to jump to for VIOLATION.
-A value violation goes to the offending field's line; a missing field
-\(which has no line yet) goes to NOTE's metadata block, or to where
-metadata would be inserted."
+A value violation goes to the offending field's line - the line carrying
+the violated value when VIOLATION names one, so distinct occurrences of a
+multi-value field resolve to distinct lines instead of all landing on the
+first.  A missing field (which has no line yet) goes to NOTE's metadata
+block, or to where metadata would be inserted."
   (let* ((path (vulpea-note-path note))
          (buf (and path (find-buffer-visiting path)))
-         (field (vulpea-violation-field violation)))
+         (field (vulpea-violation-field violation))
+         (value (vulpea-violation-value violation)))
     (or
      (when (and buf field
                 (not (eq (vulpea-violation-type violation) 'missing-required)))
        (with-current-buffer buf
          (save-excursion
-           (goto-char (vulpea-note-pos note))
-           (let ((end (vulpea-ui--schema-note-end note)))
-             (when (re-search-forward
-                    (format "^[ \t]*-[ \t]+%s[ \t]+::" (regexp-quote field))
-                    end t)
-               (line-beginning-position))))))
+           (let* ((start (vulpea-note-pos note))
+                  (end (vulpea-ui--schema-note-end note))
+                  (field-re (format "^[ \t]*-[ \t]+%s[ \t]+::"
+                                    (regexp-quote field))))
+             (or
+              ;; Prefer the line carrying the offending value.
+              (when value
+                (goto-char start)
+                (and (re-search-forward
+                      (format "%s[ \t]*%s[ \t]*$" field-re
+                              (regexp-quote (format "%s" value)))
+                      end t)
+                     (line-beginning-position)))
+              ;; Fall back to the first occurrence of the field.
+              (progn
+                (goto-char start)
+                (when (re-search-forward field-re end t)
+                  (line-beginning-position))))))))
      (vulpea-ui--schema-meta-position note))))
 
 (declare-function vulpea-schema-fix-violation "vulpea" (violation &optional bound))
 
 (defun vulpea-ui--schema-fix-violation-action (note violation)
   "Fix VIOLATION on NOTE, persist the change, and refresh the sidebar.
-Prompt for a corrected value, write it to NOTE's file, re-index, and
-re-render.  Do nothing when the prompt is skipped or NOTE's buffer is
-not visiting a file."
+Prompt for a corrected value, write it to NOTE's file (scoped to NOTE's
+heading when it is one), re-index, and re-render.  In the per-file
+breakdown, anchor point on NOTE's title row before refreshing, so when
+the fixed violation clears vui's cursor restoration lands on that note
+\(when it keeps other issues) or the nearest surviving row (when its
+title vanishes with its last issue).  In single-note mode there is no
+title row to anchor; vui's own tree recovery keeps point on a surviving
+row there.  Do nothing when the prompt is skipped or NOTE's buffer is not
+visiting a file."
   (when-let* ((path (vulpea-note-path note))
               (buf (find-buffer-visiting path)))
     (when (with-current-buffer buf
@@ -2185,17 +2279,25 @@ not visiting a file."
                (vulpea-note-pos note))))
       (with-current-buffer buf (save-buffer))
       (vulpea-db-update-file path)
+      (when (fboundp 'vui-goto-key)
+        (vui-goto-key (list 'schema-note (vulpea-note-id note))))
       (vulpea-ui-sidebar-refresh))))
 
-(defun vulpea-ui--render-schema-violation (violation note)
-  "Render one row for VIOLATION on NOTE.
+(defun vulpea-ui--render-schema-violation (violation note index)
+  "Render one row for VIOLATION on NOTE at per-note INDEX.
 The row is a severity bullet, an optional quick-fix button, the field
-name as a button that jumps to the offending field, and a terse reason."
-  (let ((face (if (eq (vulpea-ui--schema-violation-severity
-                       (vulpea-violation-type violation))
-                      'error)
-                  'vulpea-ui-schema-health-error-face
-                'vulpea-ui-schema-health-warning-face)))
+name as a button that jumps to the offending field, and a terse reason.
+NOTE's id, the field, the type and INDEX key the buttons so point keeps
+its identity across a re-render even when several notes - or several
+same-field violations on one note - are listed together."
+  (let* ((face (if (eq (vulpea-ui--schema-violation-severity
+                        (vulpea-violation-type violation))
+                       'error)
+                   'vulpea-ui-schema-health-error-face
+                 'vulpea-ui-schema-health-warning-face))
+         (note-id (vulpea-note-id note))
+         (field (vulpea-violation-field violation))
+         (type (vulpea-violation-type violation)))
     (apply
      #'vui-hstack
      (delq
@@ -2205,12 +2307,14 @@ name as a button that jumps to the offending field, and a terse reason."
        (when (fboundp 'vulpea-schema-fix-violation)
          (vui-button "fix"
            :face 'vulpea-ui-schema-health-action-face
+           :key (list 'fix note-id field type index)
            :on-click (lambda ()
                        (vulpea-ui--schema-fix-violation-action note violation))
            :help-echo "Prompt for a value and fix this violation"))
-       (vui-button (or (vulpea-violation-field violation) "")
+       (vui-button (or field "")
          :face 'vulpea-ui-schema-health-field-face
          :no-decoration t
+         :key (list 'field note-id field type index)
          :help-echo nil
          :on-click (lambda ()
                      (vulpea-ui--jump-to-position
@@ -2219,42 +2323,99 @@ name as a button that jumps to the offending field, and a terse reason."
        (vui-text (vulpea-ui--schema-violation-reason violation note)
          :face 'vulpea-ui-schema-health-message-face))))))
 
+(defun vulpea-ui--render-schema-note-entry (entry show-title)
+  "Render one violated ENTRY (a per-note health plist).
+With SHOW-TITLE, prepend the note's title as a jump button, so the
+per-file breakdown names which note each block belongs to; without it,
+render just the schema line and violation rows (the single-note look).
+The title button is keyed on the note so point can be anchored to it."
+  (let* ((note (plist-get entry :note))
+         (schemas (plist-get entry :schemas))
+         (violations (plist-get entry :violations))
+         (names (mapconcat #'symbol-name schemas ", "))
+         (summary (vui-text
+                   (format "%s %s · %d issue%s"
+                           vulpea-ui-schema-health-issue-glyph names
+                           (length violations)
+                           (if (= (length violations) 1) "" "s"))
+                   :face 'vulpea-ui-schema-health-error-face))
+         (rows (seq-map-indexed
+                (lambda (v i) (vulpea-ui--render-schema-violation v note i))
+                violations))
+         (title (when show-title
+                  (vui-button (or (vulpea-note-title note) "(untitled)")
+                    :face 'vulpea-ui-schema-health-note-face
+                    :no-decoration t
+                    :key (list 'schema-note (vulpea-note-id note))
+                    :help-echo "Jump to this note"
+                    :on-click (lambda () (vulpea-ui-visit-note note))))))
+    (apply #'vui-vstack (delq nil (append (list title summary) rows)))))
+
 (vui-defcomponent vulpea-ui-widget-schema-health ()
-  "Widget flagging schema violations for the current note.
-Renders a healthy status when the note conforms, or the list of
-violations when it does not.  The widget hides entirely when no schema
-applies (see its :predicate at registration)."
+  "Widget reporting schema health for every note in the current file.
+Covers the file-level note and each heading-level note a schema applies
+to.  With a single such note it reads as one status line plus its
+violations; with several it breaks the file down per note - the
+file-level note first, then headings in document order - each under its
+own title, so a violation on a heading is never hidden behind the
+file-level note.  A trailing count summarises any notes that are clean.
+Renders nothing when the file carries no schema-bearing note."
   :render
   (let ((note (use-vulpea-ui-note)))
     (when note
-      (let* ((note-buf (when (vulpea-note-path note)
-                         (find-buffer-visiting (vulpea-note-path note))))
+      (let* ((path (vulpea-note-path note))
+             (note-buf (when path (find-buffer-visiting path)))
              (tick (when note-buf (buffer-modified-tick note-buf)))
-             (health (vui-use-memo (note tick)
-                       (vulpea-ui--schema-health note))))
-        (when health
-          (let* ((schemas (plist-get health :schemas))
-                 (violations (plist-get health :violations))
-                 (names (mapconcat #'symbol-name schemas ", ")))
+             (health (vui-use-memo (note tick vulpea-ui--refresh-generation)
+                       (vulpea-ui--schema-file-health
+                        (vulpea-ui--schema-file-notes path))))
+             (entries (plist-get health :entries)))
+        (when entries
+          (let* ((violated (plist-get health :violated))
+                 (issue-count (plist-get health :issue-count))
+                 (healthy-count (plist-get health :healthy-count))
+                 (multi (> (length entries) 1)))
             (vui-component 'vulpea-ui-widget
               :title "Schema"
-              :count (when violations (length violations))
+              :count (when (> issue-count 0) issue-count)
               :children
               (lambda ()
-                (if violations
-                    (apply #'vui-vstack
-                           (vui-text (format "%s %s · %d issue%s"
-                                             vulpea-ui-schema-health-issue-glyph
-                                             names
-                                             (length violations)
-                                             (if (= (length violations) 1) "" "s"))
-                             :face 'vulpea-ui-schema-health-error-face)
-                           (seq-map (lambda (v)
-                                      (vulpea-ui--render-schema-violation v note))
-                                    violations))
-                  (vui-text (format "%s %s · healthy"
-                                    vulpea-ui-schema-health-ok-glyph names)
-                    :face 'vulpea-ui-schema-health-ok-face))))))))))
+                (cond
+                 ;; Nothing wrong anywhere in the file.
+                 ((null violated)
+                  (vui-text
+                   (if multi
+                       (format "%s %d notes · healthy"
+                               vulpea-ui-schema-health-ok-glyph (length entries))
+                     (format "%s %s · healthy"
+                             vulpea-ui-schema-health-ok-glyph
+                             (mapconcat #'symbol-name
+                                        (plist-get (car entries) :schemas) ", ")))
+                   :face 'vulpea-ui-schema-health-ok-face))
+                 ;; Single schema-bearing note: the classic per-note view.
+                 ((not multi)
+                  (vulpea-ui--render-schema-note-entry (car violated) nil))
+                 ;; Several notes in the file: break it down per note.
+                 (t
+                  (apply
+                   #'vui-vstack
+                   :spacing 1
+                   (vui-text
+                    (format "%s %d note%s · %d issue%s"
+                            vulpea-ui-schema-health-issue-glyph
+                            (length violated) (if (= (length violated) 1) "" "s")
+                            issue-count (if (= issue-count 1) "" "s"))
+                    :face 'vulpea-ui-schema-health-error-face)
+                   (append
+                    (seq-map (lambda (e)
+                               (vulpea-ui--render-schema-note-entry e t))
+                             violated)
+                    (when (> healthy-count 0)
+                      (list (vui-muted
+                             (format "%s %d note%s healthy"
+                                     vulpea-ui-schema-health-ok-glyph
+                                     healthy-count
+                                     (if (= healthy-count 1) "" "s")))))))))))))))))
 
 
 ;;; Built-in widget registration
@@ -2265,10 +2426,15 @@ applies (see its :predicate at registration)."
 
 (vulpea-ui-register-widget 'schema-health
                            :component 'vulpea-ui-widget-schema-health
-                           :predicate (lambda (note)
-                                        (and note
-                                             (fboundp 'vulpea-schema-note-violations)
-                                             (vulpea-schema-applicable note)))
+                           ;; Feature-detect only; the widget itself hides
+                           ;; (renders nothing) when the file has no
+                           ;; schema-bearing note, and it looks at every note
+                           ;; in the file, not just the one anchoring the
+                           ;; sidebar - so an applicable-schema check on that
+                           ;; one note would wrongly hide it for heading-only
+                           ;; schema files.
+                           :predicate (lambda (_note)
+                                        (fboundp 'vulpea-schema-note-violations))
                            :order 150)
 
 (vulpea-ui-register-widget 'outline


### PR DESCRIPTION
The schema health widget only ever looked at the file-level note, so if you kept a schema on a heading - an `:execution:` heading inside a `:journal:` file, say - its violations just never showed up in the sidebar. This is the vulpea-ui side of what [vulpea#356](https://github.com/d12frosted/vulpea/issues/356) / [#357](https://github.com/d12frosted/vulpea/pull/357) fixed on the authoring side.

Now the widget reports on the whole file. A single schema-bearing note reads exactly like before; several get a per-file breakdown - the file-level note first, then headings in document order - each violated note under its title (click to jump there) with a `✓ N healthy` count for the clean ones. Fixing a heading's field writes into that heading's subtree, not the top of the file.

A few related things came along for the ride:

- **Heading-only files** (where only headings carry IDs) now light up the sidebar instead of showing nothing.
- A note's scope now stops at its **first child heading**, so a missing-field jump no longer leaks into a sub-heading's metadata.
- A **multi-value `:one-of` failure** jumps to the offending value's line rather than always the first occurrence - this one also fixes the schema dashboard.

The sidebar still anchors on the file-level note, so the other widgets (outline, backlinks, stats) stay file-scoped; only the schema widget looks across the whole file.

I ran a couple of adversarial self-review passes over this before opening it, which caught a real regression (the heading-only fallback firing when a file's ID simply hadn't synced yet) and a small pre-existing dashboard nit - both fixed here.