### PR TITLE
fix: anchor sidebar on the most recently used main window

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -46,6 +46,8 @@ All notable changes to this project will be documented in this file.
 
 ** Fixed
 
+- Focusing the sidebar no longer flips its context to the wrong note ([[https://github.com/d12frosted/vulpea-ui/issues/57][#57]]). With two stacked note windows, moving point into the sidebar made it show the *first* window's note instead of the one just edited: the main-window fallback walked =window-list= in cyclic order, so the topmost window always won. It now picks the main window with the highest =window-use-time= - the most recently used one, as the docstring promised all along.
+
 - The schema health widget and the schema dashboard now jump to the right line for a field that fails =:one-of= on more than one of its values. =vulpea-ui--schema-violation-position= matched on the field name alone, so each disallowed value of a multi-value field jumped to that field's *first* line; it now prefers the line carrying the offending value, falling back to the first occurrence when the value cannot be matched textually.
 
 - The schema health widget was blind to heading-level notes: it always resolved the file-level note and reported only that one's schema, so a violation on an =:execution:= heading inside a schema-less =:journal:= file was invisible in the sidebar (the counterpart, on the authoring side, to [[https://github.com/d12frosted/vulpea/issues/356][vulpea#356]]). It now looks at the whole file, so heading violations surface regardless of where point sits. The lower-level scoping helpers (=vulpea-ui--schema-note-end=, =-meta-position=, =-violation-position=) were already heading-aware but had never been exercised on a heading; they now have coverage.

--- a/test/vulpea-ui-test.el
+++ b/test/vulpea-ui-test.el
@@ -244,6 +244,43 @@ https://github.com/d12frosted/vulpea-ui/issues/36)."
         (when (buffer-live-p main-buf) (kill-buffer main-buf))
         (when (buffer-live-p side-buf) (kill-buffer side-buf))))))
 
+(ert-deftest vulpea-ui-test-get-main-window-prefers-mru ()
+  "`vulpea-ui--get-main-window' picks the most recently used main window.
+With two stacked main windows, working in the bottom one and then
+focusing the sidebar must keep the bottom window as the main window.
+The old fallback walked `window-list' in cyclic order, so the top
+window always won and the sidebar flipped to the wrong note (see
+https://github.com/d12frosted/vulpea-ui/issues/57)."
+  (save-window-excursion
+    (let* ((buf-a (get-buffer-create " *vulpea-ui-test-top*"))
+           (buf-b (get-buffer-create " *vulpea-ui-test-bottom*"))
+           (sidebar-buf (get-buffer-create (vulpea-ui--sidebar-buffer-name)))
+           top-win bottom-win sidebar-win)
+      (unwind-protect
+          (progn
+            (delete-other-windows)
+            (switch-to-buffer buf-a)
+            (setq top-win (selected-window)
+                  bottom-win (split-window-below))
+            (set-window-buffer bottom-win buf-b)
+            (setq sidebar-win (display-buffer-in-side-window
+                               sidebar-buf '((side . right) (slot . 0))))
+            ;; The user works in the bottom window, then focuses the
+            ;; sidebar.  The bottom window is the most recently used
+            ;; main window and must stay the anchor.
+            (select-window bottom-win)
+            (select-window sidebar-win)
+            (should (eq (vulpea-ui--get-main-window) bottom-win))
+            ;; And the other way around: work in the top window last.
+            (select-window bottom-win)
+            (select-window top-win)
+            (select-window sidebar-win)
+            (should (eq (vulpea-ui--get-main-window) top-win)))
+        (when (window-live-p sidebar-win)
+          (ignore-errors (delete-window sidebar-win)))
+        (dolist (buf (list buf-a buf-b sidebar-buf))
+          (when (buffer-live-p buf) (kill-buffer buf)))))))
+
 
 ;;; Sidebar render tests
 

--- a/vulpea-ui.el
+++ b/vulpea-ui.el
@@ -459,7 +459,14 @@ main editing window, so focusing one must not be mistaken for switching
 away from the vulpea note.  Treating such a window as the main one made
 `vulpea-ui--on-buffer-change' auto-hide and then re-show the sidebar on
 every focus change, which under `window-combination-resize' steadily
-shrank the note window (see vulpea-ui#36)."
+shrank the note window (see vulpea-ui#36).
+
+When no main window is selected (the sidebar itself is), the fallback
+picks the main window with the highest `window-use-time' - the one the
+user was just editing.  Walking `window-list' in cyclic order instead
+made the topmost window win, so with two stacked note windows focusing
+the sidebar flipped its context to the first buffer (see
+vulpea-ui#57)."
   (let* ((frame (or frame (selected-frame)))
          (sidebar-win (vulpea-ui--get-sidebar-window frame))
          (selected (frame-selected-window frame))
@@ -470,8 +477,10 @@ shrank the note window (see vulpea-ui#36)."
     ;; Prefer the currently selected window if it's a valid main window
     (if (and selected (funcall mainp selected))
         selected
-      ;; Fallback to first valid window
-      (or (seq-find mainp (window-list frame nil))
+      ;; Fallback to the most recently used valid window
+      (or (car (sort (seq-filter mainp (window-list frame nil))
+                     (lambda (a b)
+                       (> (window-use-time a) (window-use-time b)))))
           (frame-first-window frame)))))
 
 


### PR DESCRIPTION
Fixes #57.

The repro from the issue: two note windows stacked in one frame, point in the second one, sidebar correctly shows its context. Move point into the sidebar and the context flips to the first window's note.

Turns out `vulpea-ui--get-main-window` promised "the most recently used main window" in its docstring but never actually consulted `window-use-time`. When the sidebar itself is selected, the fallback walked `window-list` in cyclic order, so the topmost window always won. That's also why it only bites "sometimes" - it depends on whether the buffer you were in happens to come first in that order.

The fix is to sort the main-window candidates by `window-use-time` and take the freshest one. This also fixes the idle refresh (`vulpea-ui--on-idle`), which goes through the same function and would otherwise flip the context back on its own.

Comes with an ERT test mirroring the repro (two stacked mains plus a side-window sidebar, checked in both directions) and a changelog entry.